### PR TITLE
Maya includes "Maya" in it's version name for service pack releases

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -226,6 +226,8 @@ class MayaEngine(tank.platform.Engine):
                                  "are Mac, Linux 64 and Windows 64.")
         
         maya_ver = cmds.about(version=True)
+        if maya_ver.startswith("Maya "):
+            maya_ver = maya_ver[5:]
         if maya_ver.startswith(("2012", "2013", "2014")):
             self.log_debug("Running Maya version %s" % maya_ver)
         else:


### PR DESCRIPTION
For the SP1 and SP3 releases of Maya 2014, running:

```
cmds.about(version=True)
```

yields "Maya 2014 Servic..." breaking the tradition of formats like "2014 x64" (as yielded from the regular 2014 release)

This patch allows for both formats to be considered valid Maya 2014 releases.
