### PR TITLE
For #25216 - Added support for Maya 2015.

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -43,6 +43,13 @@ configuration:
         description: Optionally choose to use 'Sgtk' as the primary menu name instead of 'Shotgun'
         default_value: false
 
+    compatibility_dialog_min_version:
+        type:           int
+        description:    "Specify the minimum Application major version that will prompt a warning if
+                        it isn't yet fully supported and tested with Toolkit.  To disable the warning
+                        dialog for the version you are testing, it is recomended that you set this
+                        value to the current major version + 1."
+        default_value:  2015
 
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:


### PR DESCRIPTION
- Maya 2015 is now officially supported by Toolkit.
- Unsupported versions no longer cause Toolkit not to load but instead
  present a warning to the user.
- Added a setting to allow Toolkit to be used with future unsupported
  versions if needed.
