### PR TITLE
Cast the menu label to unicode in order to preserve non-ascii text

### DIFF
--- a/python/tk_maya/menu_generation.py
+++ b/python/tk_maya/menu_generation.py
@@ -108,8 +108,10 @@ class MenuGenerator(object):
         ctx_name = str(ctx)        
         
         # create the menu object
-        ctx_menu = pm.subMenuItem(label=ctx_name, parent=self._menu_handle)
-        
+        # the label expects a unicode object so we cast it to support when the context may 
+        # contain info with non-ascii characters
+        ctx_menu = pm.subMenuItem(label=ctx_name.decode("utf-8"), parent=self._menu_handle)
+
         # link to UI
         pm.menuItem(label="Jump to Shotgun", 
                     parent=ctx_menu, 


### PR DESCRIPTION
pymel expects a unicode object to be passed in to create the menu label. Previously we were sending it as a string. When the Toolkit context contains non-ascii characters, for example if an Asset name is in Japanese, this caused garbled characters to display in the menu. By casting the context string as unicode, any non-ascii characters will be preserved in the menu.