### PR TITLE
#29765 Added support for toolkit panels

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -561,6 +561,11 @@ class MayaEngine(tank.platform.Engine):
         
         if pm.control(widget_id, query=1, exists=1):
             self.log_debug("Toolkit widget already exists. Reparenting it...")
+            # find the widget for later use
+            for widget in QtGui.QApplication.allWidgets():
+             if widget.objectName() == widget_id:
+                 widget_instance = widget
+            
         else:
             self.log_debug("Toolkit widget does not exist - creating it...")
             parent = self._get_dialog_parent()            
@@ -592,7 +597,16 @@ class MayaEngine(tank.platform.Engine):
             pm.deleteUI(panel_id)
                     
         # lastly, ditch the maya window and host the layout inside a dock
-        pm.dockControl(panel_id, area="right", content=window, label=title)
+        
+        # see if the app has a preference where it likes to be docked:
+        if hasattr(widget_instance, "docking_preference"):
+            docking_area = widget_instance.docking_preference
+            self.log_debug("App docking preference found: %s" % docking_area)
+        else:
+            docking_area = "right"
+            self.log_debug("Now docking preference found. Using default: %s" % docking_area)
+        
+        pm.dockControl(panel_id, area=docking_area, content=window, label=title)
         self.log_debug("Created panel %s" % panel_id)
     
         # just like nuke, maya doesn't give us any hints when a panel is being closed.

--- a/engine.py
+++ b/engine.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Shotgun Software Inc.
+# Copyright (c) 2015 Shotgun Software Inc.
 # 
 # CONFIDENTIAL AND PROPRIETARY
 # 
@@ -426,7 +426,8 @@ class MayaEngine(tank.platform.Engine):
     def log_debug(self, msg):
         """
         Log debug to the Maya script editor
-        :param msg:    The message to log
+        
+        :param msg: The message to log
         """
         global g_last_message_time
         
@@ -446,7 +447,8 @@ class MayaEngine(tank.platform.Engine):
     def log_info(self, msg):
         """
         Log info to the Maya script editor
-        :param msg:    The message to log
+        
+        :param msg: The message to log
         """
         msg = "Shotgun: %s" % msg
         self.execute_in_main_thread(OpenMaya.MGlobal.displayInfo, msg)
@@ -454,7 +456,8 @@ class MayaEngine(tank.platform.Engine):
     def log_warning(self, msg):
         """
         Log warning to the Maya script editor
-        :param msg:    The message to log
+        
+        :param msg: The message to log
         """
         msg = "Shotgun: %s" % msg
         self.execute_in_main_thread(OpenMaya.MGlobal.displayWarning, msg)
@@ -462,7 +465,8 @@ class MayaEngine(tank.platform.Engine):
     def log_error(self, msg):
         """
         Log error to the Maya script editor
-        :param msg:    The message to log
+        
+        :param msg: The message to log
         """
         msg = "Shotgun: %s" % msg
         self.execute_in_main_thread(OpenMaya.MGlobal.displayError, msg)
@@ -490,14 +494,14 @@ class MayaEngine(tank.platform.Engine):
     
     def _generate_panel_id(self, dialog_name, bundle):
         """
-        Given a dialog name and a bundle, generate a Nuke panel id.
-        This panel id is used by Nuke to identify and persist the panel.
+        Given a dialog name and a bundle, generate a Maya panel id.
+        This panel id is used by Maya to identify and persist the panel.
         
         This will return something like 'tk_multi_loader2_main'
         
         :param dialog_name: An identifier string to identify the dialog to be hosted by the panel
         :param bundle: The bundle (e.g. app) object to be associated with the panel
-        :returns: a unique identifier string 
+        :returns: A unique identifier string 
         """
         panel_id = "%s_%s" % (bundle.name, dialog_name)
         # replace any non-alphanumeric chars with underscores
@@ -515,10 +519,10 @@ class MayaEngine(tank.platform.Engine):
         Just like with the register_command() method, panel registration should be executed 
         from within the init phase of the app. Once a panel has been registered, it is possible
         for the engine to correctly restore panel UIs that persist between sessions. 
-        
-        Not all engines support this feature, but in for example Nuke, a panel can be saved in 
-        a saved layout. Apps wanting to be able to take advantage of the persistance given by
-        these saved layouts will need to call register_panel as part of their init_app phase.
+
+        Maya currently doesn't implement any logic for automatically restoring panels, 
+        however we still recommend that all panel based apps call this method in order
+        to provide a good user experience across multiple engines. 
         
         In order to show or focus on a panel, use the show_panel() method instead.
         
@@ -549,10 +553,51 @@ class MayaEngine(tank.platform.Engine):
         
         tk_maya = self.import_module("tk_maya")
         
+        # generate some unique window names for both the panel
+        # and the widget that will be contained in the panel
+        #
+        # these will appear as object names in QT and as the main
+        # api handles inside the maya UI framework
         panel_id = self._generate_panel_id(title, bundle)
         widget_id = "ui_%s" % panel_id
         self.log_debug("Begin showing panel %s" % panel_id)
                                     
+        
+        # The general approach below is as follows:
+        #
+        # 1. First create our qt tk app widget using QT.
+        #    parent it to the maya main window to give it
+        #    a well established parent. If the widget already
+        #    exists, don't create it again, just retrieve its 
+        #    handle
+        #
+        # 2. Now create a native maya window and layout and 
+        #    attach our QT control to this. For this, we use
+        #    the QT objectname property to do the bind. Note that
+        #    the window won't show in the UI, this is all just 
+        #    setting up the hiearchy.
+        #    
+        # 3. If a panel already exists, delete it. The panel 
+        #    no longer has the tk widget inside it, since that is
+        #    parented to the window that was just created
+        #
+        # 4. Create a new panel using the dockControl command and
+        #    pass our maya window in as the object to dock.
+        #
+        # 5. Lastly, since our widgets won't get notified about 
+        #    when the parent dock is closed (and sometimes when it
+        #    needs redrawing), attach some QT event watchers to it
+        #
+        #
+        # Note: It is possible that the close event and some of the 
+        #       refresh doesn't propagate down to the widget because
+        #       of a misaligned parenting: The tk widget exists inside
+        #       the pane layout but is still parented to the main 
+        #       maya window. It's possible that by setting up the parenting
+        #       explicitly, the missing signals we have to compensate for 
+        #       may start to work. I tried a bunch of stuff but couldn't get
+        #       it to work and instead resorted to the event watcher setup. 
+        
         # create a maya window and layout
         window = pm.window()
         self.log_debug("Created window: %s" % window)
@@ -563,14 +608,17 @@ class MayaEngine(tank.platform.Engine):
             self.log_debug("Toolkit widget already exists. Reparenting it...")
             # find the widget for later use
             for widget in QtGui.QApplication.allWidgets():
-             if widget.objectName() == widget_id:
-                 widget_instance = widget
+                if widget.objectName() == widget_id:
+                    widget_instance = widget
+                    break
             
         else:
             self.log_debug("Toolkit widget does not exist - creating it...")
+            # parent the UI to the main maya window
             parent = self._get_dialog_parent()            
             widget_instance = widget_class(*args, **kwargs)
             widget_instance.setParent(parent)
+            # set its name - this means that it can also be found via the maya API
             widget_instance.setObjectName(widget_id)
             self.log_debug("Created %s (Object Name '%s')" % (widget_instance, widget_id))
             # apply external stylesheet
@@ -596,17 +644,8 @@ class MayaEngine(tank.platform.Engine):
             self.log_debug("Panel exists. Deleting it.")
             pm.deleteUI(panel_id)
                     
-        # lastly, ditch the maya window and host the layout inside a dock
-        
-        # see if the app has a preference where it likes to be docked:
-        if hasattr(widget_instance, "docking_preference"):
-            docking_area = widget_instance.docking_preference
-            self.log_debug("App docking preference found: %s" % docking_area)
-        else:
-            docking_area = "right"
-            self.log_debug("Now docking preference found. Using default: %s" % docking_area)
-        
-        pm.dockControl(panel_id, area=docking_area, content=window, label=title)
+        # lastly, move the maya window into a dock
+        pm.dockControl(panel_id, area="right", content=window, label=title)
         self.log_debug("Created panel %s" % panel_id)
     
         # just like nuke, maya doesn't give us any hints when a panel is being closed.

--- a/engine.py
+++ b/engine.py
@@ -16,6 +16,7 @@ A Maya engine for Tank.
 import tank
 import platform
 import sys
+import re
 import traceback
 import time
 import textwrap
@@ -25,8 +26,6 @@ import pymel.core as pm
 import maya.cmds as cmds
 import maya
 from pymel.core import Callback
-
-CONSOLE_OUTPUT_WIDTH = 200
 
 ###############################################################################################
 # methods to support the state when the engine cannot start up
@@ -484,4 +483,106 @@ class MayaEngine(tank.platform.Engine):
         proj_path = tmpl.apply_fields(fields)
         self.log_info("Setting Maya project to '%s'" % proj_path)        
         pm.mel.setProject(proj_path)
+    
+
+    ##########################################################################################
+    # panel support            
+    
+    def _generate_panel_id(self, dialog_name, bundle):
+        """
+        Given a dialog name and a bundle, generate a Nuke panel id.
+        This panel id is used by Nuke to identify and persist the panel.
+        
+        This will return something like 'tk_multi_loader2_main'
+        
+        :param dialog_name: An identifier string to identify the dialog to be hosted by the panel
+        :param bundle: The bundle (e.g. app) object to be associated with the panel
+        :returns: a unique identifier string 
+        """
+        panel_id = "%s_%s" % (bundle.name, dialog_name)
+        # replace any non-alphanumeric chars with underscores
+        panel_id = re.sub("\W", "_", panel_id)
+        panel_id = panel_id.lower()
+        self.log_debug("Unique panel id for %s %s -> %s" % (bundle, dialog_name, panel_id))
+        return panel_id    
+    
+    def register_panel(self, title, bundle, widget_class, *args, **kwargs):
+        """
+        Similar to register_command, but instead of registering a menu item in the form of a
+        command, this method registers a UI panel. The arguments passed to this method is the
+        same as for show_panel().
+        
+        Just like with the register_command() method, panel registration should be executed 
+        from within the init phase of the app. Once a panel has been registered, it is possible
+        for the engine to correctly restore panel UIs that persist between sessions. 
+        
+        Not all engines support this feature, but in for example Nuke, a panel can be saved in 
+        a saved layout. Apps wanting to be able to take advantage of the persistance given by
+        these saved layouts will need to call register_panel as part of their init_app phase.
+        
+        In order to show or focus on a panel, use the show_panel() method instead.
+        
+        :param title: The title of the window
+        :param bundle: The app, engine or framework object that is associated with this panel
+        :param widget_class: The class of the UI to be constructed. This must derive from QWidget.
+        
+        Additional parameters specified will be passed through to the widget_class constructor.
+        """
+        # maya doesn't support the concept of saved panels
+        # may be able to use the panelConfiguration command here.
+        pass        
+        
+    def show_panel(self, title, bundle, widget_class, *args, **kwargs):
+        """
+        Shows a panel in a way suitable for this engine. The engine will attempt to
+        integrate it as seamlessly as possible into the host application. If the engine does 
+        not specifically implement panel support, the window will be shown as a modeless
+        dialog instead.
+        
+        :param title: The title of the window
+        :param bundle: The app, engine or framework object that is associated with this window
+        :param widget_class: The class of the UI to be constructed. This must derive from QWidget.
+        
+        Additional parameters specified will be passed through to the widget_class constructor.
+        """
+        
+        panel_id = self._generate_panel_id(title, bundle)
+        widget_id = "ui_%s" % panel_id
+        self.log_debug("Begin showing panel %s" % panel_id)
+                                    
+        # create a maya window and layout
+        w = pm.window()
+        self.log_debug("Created window: %s" % w)
+        maya_layout = pm.columnLayout(parent=w)
+        self.log_debug("Created layout %s" % maya_layout)
+        
+        if pm.control(widget_id, q=1, ex=1):
+            self.log_debug("Toolkit widget already exists. Reparenting it...")
+        else:
+            self.log_debug("Toolkit widget does not exist - creating it...")
+            parent = self._get_dialog_parent()            
+            widget_instance = widget_class(*args, **kwargs)
+            widget_instance.setParent(parent)
+            widget_instance.setObjectName(widget_id)
+            self.log_debug("Created %s (Object Name '%s')" % (widget_instance, widget_id))
+                      
+        
+        # now reparent the widget instance to the layout
+        # we can now refer to the QT widget via the widget name
+        self.log_debug("Parenting widget %s to temporary window %s..." % (widget_id, maya_layout))
+        pm.control(widget_id, e=True, p=maya_layout)
+        
+        if pm.control(panel_id, q=1, ex=1):
+            # exists already - delete it
+            self.log_debug("Panel exists. Deleting it.")
+            pm.deleteUI(panel_id)
+                    
+        # lastly, ditch the maya window and host the layout inside a dock
+        pm.dockControl(panel_id, area="right", content=w, label=title)
+        self.log_debug("Created panel %s" % panel_id)
+    
+            
+        
+        
+        
     

--- a/engine.py
+++ b/engine.py
@@ -554,12 +554,12 @@ class MayaEngine(tank.platform.Engine):
         self.log_debug("Begin showing panel %s" % panel_id)
                                     
         # create a maya window and layout
-        w = pm.window()
-        self.log_debug("Created window: %s" % w)
-        maya_layout = pm.columnLayout(parent=w)
+        window = pm.window()
+        self.log_debug("Created window: %s" % window)
+        maya_layout = pm.formLayout(parent=window)
         self.log_debug("Created layout %s" % maya_layout)
         
-        if pm.control(widget_id, q=1, ex=1):
+        if pm.control(widget_id, query=1, exists=1):
             self.log_debug("Toolkit widget already exists. Reparenting it...")
         else:
             self.log_debug("Toolkit widget does not exist - creating it...")
@@ -575,15 +575,24 @@ class MayaEngine(tank.platform.Engine):
         # now reparent the widget instance to the layout
         # we can now refer to the QT widget via the widget name
         self.log_debug("Parenting widget %s to temporary window %s..." % (widget_id, maya_layout))
-        pm.control(widget_id, e=True, p=maya_layout)
+        pm.control(widget_id, edit=True, parent=maya_layout)
         
-        if pm.control(panel_id, q=1, ex=1):
+        # now attach our widget in all four corners to the maya layout so that it fills 
+        # the entire panel space
+        pm.formLayout(maya_layout, 
+                      edit=True, 
+                      attachForm=[(widget_id, 'top', 1), 
+                                  (widget_id, 'left', 1), 
+                                  (widget_id, 'bottom', 1), 
+                                  (widget_id, 'right', 1)] )
+        
+        if pm.control(panel_id, query=1, exists=1):
             # exists already - delete it
             self.log_debug("Panel exists. Deleting it.")
             pm.deleteUI(panel_id)
                     
         # lastly, ditch the maya window and host the layout inside a dock
-        pm.dockControl(panel_id, area="right", content=w, label=title)
+        pm.dockControl(panel_id, area="right", content=window, label=title)
         self.log_debug("Created panel %s" % panel_id)
     
         # just like nuke, maya doesn't give us any hints when a panel is being closed.

--- a/engine.py
+++ b/engine.py
@@ -604,7 +604,12 @@ class MayaEngine(tank.platform.Engine):
         #
         # instead, install a QT event watcher to track when the parent
         # is closed and make sure that the tk widget payload is closed and
-        # deallocated at the same time  
-        tk_maya.install_close_callback(panel_id, widget_id)
+        # deallocated at the same time.
+        #
+        # Also, there are some obscure issues relating to UI refresh. These are also
+        # resolved by looking at the stream of event and force triggering refreshes at the 
+        # right locations
+        #  
+        tk_maya.install_callbacks(panel_id, widget_id)
 
         

--- a/info.yml
+++ b/info.yml
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Shotgun Software Inc.
+# Copyright (c) 2015 Shotgun Software Inc.
 # 
 # CONFIDENTIAL AND PROPRIETARY
 # 

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Shotgun Software Inc.
+# Copyright (c) 2015 Shotgun Software Inc.
 # 
 # CONFIDENTIAL AND PROPRIETARY
 # 

--- a/python/tk_maya/__init__.py
+++ b/python/tk_maya/__init__.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Shotgun Software Inc.
+# Copyright (c) 2015 Shotgun Software Inc.
 # 
 # CONFIDENTIAL AND PROPRIETARY
 # 

--- a/python/tk_maya/__init__.py
+++ b/python/tk_maya/__init__.py
@@ -9,4 +9,4 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .menu_generation import MenuGenerator
-
+from .panels import install_close_callback

--- a/python/tk_maya/__init__.py
+++ b/python/tk_maya/__init__.py
@@ -9,4 +9,4 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .menu_generation import MenuGenerator
-from .panels import install_close_callback
+from .panels import install_callbacks

--- a/python/tk_maya/menu_generation.py
+++ b/python/tk_maya/menu_generation.py
@@ -1,4 +1,4 @@
-# Copyright (c) 2013 Shotgun Software Inc.
+# Copyright (c) 2015 Shotgun Software Inc.
 # 
 # CONFIDENTIAL AND PROPRIETARY
 # 
@@ -305,8 +305,7 @@ class AppCommand(object):
             callback()
         except Exception, e:
             current_engine = tank.platform.current_engine()
-            if current_engine:
-                current_engine.log_exception("An exception was raised from Toolkit")        
+            current_engine.log_exception("An exception was raised from Toolkit")        
     
     def __execute_deferred(self):
         """

--- a/python/tk_maya/menu_generation.py
+++ b/python/tk_maya/menu_generation.py
@@ -284,7 +284,7 @@ class AppCommand(object):
         # finally create the command menu item:
         params = {
             "label": parts[-1],#self.name,
-            "command": Callback(self.__execute_deferred),#self.callback),
+            "command": Callback(self.__execute_deferred),
             "parent": parent_menu,
         }
         if "tooltip" in self.properties:
@@ -294,6 +294,20 @@ class AppCommand(object):
             
         pm.menuItem(**params)
         
+    def __exception_trap_callback_wrapper(self, callback):
+        """
+        Wrapper which traps exceptions. We execute menu commands
+        in maya via evaldeferred, meaning that all errors are just
+        swallowed by maya never to resurface. This wrapper prints 
+        them out.
+        """
+        try:
+            callback()
+        except Exception, e:
+            current_engine = tank.platform.current_engine()
+            if current_engine:
+                current_engine.log_exception("An exception was raised from Toolkit")        
+    
     def __execute_deferred(self):
         """
         Execute the callback deferred to avoid
@@ -302,7 +316,8 @@ class AppCommand(object):
         changes resulting in an engine restart! - this
         was causing a segmentation fault crash on Linux
         """
-        cmds.evalDeferred(self.callback)
+        cb = lambda: self.__exception_trap_callback_wrapper(self.callback)
+        cmds.evalDeferred(cb)
         
     def _find_sub_menu_item(self, menu, label):
         """

--- a/python/tk_maya/panels.py
+++ b/python/tk_maya/panels.py
@@ -1,0 +1,89 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+Panel support utilities for Maya
+"""
+
+
+
+import os
+import sys
+import sgtk
+
+from sgtk.platform.qt import QtCore, QtGui
+
+
+def install_close_callback(panel_id, widget_id):
+    """
+    Helper method to assist in the panel creation process.
+    This will iterate over all QT widgets and look for a panel_id
+    widget. Once found, it will install an event filter on this panel
+    to monitor its close event, so that we can gracefully handle close
+    and deallocation of the embedded tk widget when this happens.
+    
+    :param panel_id: Object name for panel
+    :param widget_id: Object name for tk widget
+    """
+    for widget in QtGui.QApplication.allWidgets():
+     if widget.objectName() == panel_id:
+         filter = CloseEventFilter(widget)
+         filter.set_associated_widget(widget_id)
+         filter.parent_closed.connect(_on_parent_closed_callback)
+         widget.installEventFilter(filter)
+
+
+def _on_parent_closed_callback(widget_id):
+    """
+    Callback which fires when a panel is closed.
+    This will locate the widget with the given id
+    and close and delete this.
+    
+    :param widget_id: Object name of widget to close
+    """
+    for widget in QtGui.QApplication.allWidgets():
+        if widget.objectName() == widget_id:
+            widget.close()
+            # delete later since we are inside a slot
+            widget.deleteLater()
+    
+
+class CloseEventFilter(QtCore.QObject):
+    """
+    Event filter which emits a parent_closed signal whenever
+    the monitored widget closes.
+    """
+    parent_closed = QtCore.Signal(str)
+     
+    def set_associated_widget(self, widget_id):
+        """
+        Set the widget that should be closed
+        
+        :param widget_id: Object name of widget to close
+        """
+        self._widget_id = widget_id
+     
+    def eventFilter(self, obj, event):
+        """
+        QT Event filter callback
+        
+        :param obj: The object where the event originated from
+        :param event: The actual event object
+        :returns: True if event was consumed, False if not
+        """
+        # peek at the message
+        if event.type() == QtCore.QEvent.Close:
+            # re-broadcast the close event
+            self.parent_closed.emit(self._widget_id)
+        # pass it on!
+        return False
+
+
+


### PR DESCRIPTION
It's now possible to register panels in maya using the new panel interface methods that are being introduced in core. Here's an example:

![screen shot 2015-07-07 at 14 14 28](https://cloud.githubusercontent.com/assets/337710/8547089/64ecc16e-24b4-11e5-9147-e946fbb57249.png)

This change implements the show_panel() method, making it possible to start a new panel. The panels are 'singletons', meaning that a UI can only exist once. Clicking it again on the menu will result in the existing panel being brought forward.