### PR TITLE
For #30584 - Replaced use of evalDeferred with single shot QTimer

### DIFF
--- a/python/tk_maya/menu_generation.py
+++ b/python/tk_maya/menu_generation.py
@@ -303,7 +303,7 @@ class AppCommand(object):
         # note that we use a single shot timer instead of cmds.evalDeferred as we were experiencing
         # odd behaviour when the deferred command presented a modal dialog that then performed a file 
         # operation that resulted in a QMessageBox being shown - the deferred command would then run 
-        # a second time, presumable from the event loop of the modal dialog from the first command!
+        # a second time, presumably from the event loop of the modal dialog from the first command!
         #
         # As the primary purpose of this method is to detach the executing code from the menu invocation,
         # using a singleShot timer achieves this without the odd behaviour exhibited by evalDeferred.


### PR DESCRIPTION
The use of evalDeferred to execute menu commands was exhibiting strange behaviour and instability in some situations.  

For example, when showing a modal dialog that performed a new-file operation and then presented a message box to the user, the command would be run a second time, possibly from the event loop of the message dialog which would lead to Maya crashing.  The following code illustrates the issue:

```python
from PySide import QtGui
import maya.cmds as cmds

class TestDialog(QtGui.QDialog):
    def __init__(self, parent=None):
        QtGui.QDialog.__init__(self, parent)
        
        layout = QtGui.QVBoxLayout(self)
        btn = QtGui.QPushButton("Click Me", self)
        btn.clicked.connect(self._on_btn_clicked)
        layout.addWidget(btn)
        self.setLayout(layout)
        
    def _on_btn_clicked(self):
        # perform a new-file operation
        cmds.file(newFile=True, force=True)
        # show a message box
        QtGui.QMessageBox.warning(None, "Blah", "blah blah blah...")

def show_test_dlg():
    dlg = TestDialog()
    # show the dialog as modal:
    dlg.exec_()

# use evalDeferred to show the dialog
cmds.evalDeferred(show_test_dlg)
```

By clicking on the button recursively you can end up with something like this:
![image](https://cloud.githubusercontent.com/assets/2451760/9222815/d19a9170-40ec-11e5-96cb-ba32fcfe01c9.png)
!

To avoid this evalDeferred has been replaced with a single-shot QTimer

