### PR TITLE
33062 Adds a call to log a user metric for the DCC version

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -290,7 +290,8 @@ class MayaEngine(tank.platform.Engine):
             # always log the warning to the script editor:
             self.log_warning(msg)
         
-        self._maya_version = maya_ver  
+        self._maya_version = maya_ver
+        self.log_user_attribute_metric("Maya version", maya_ver)
         
         if self.context.project is None:
             # must have at least a project in the context to even start!

--- a/engine.py
+++ b/engine.py
@@ -291,7 +291,12 @@ class MayaEngine(tank.platform.Engine):
             self.log_warning(msg)
         
         self._maya_version = maya_ver
-        self.log_user_attribute_metric("Maya version", maya_ver)
+
+        try:
+            self.log_user_attribute_metric("Maya version", maya_ver)
+        except:
+            # ignore all errors. ex: using a core that doesn't support metrics
+            pass
         
         if self.context.project is None:
             # must have at least a project in the context to even start!

--- a/info.yml
+++ b/info.yml
@@ -62,4 +62,3 @@ description: "Shotgun Integration in Maya"
 requires_shotgun_version:
 requires_core_version: "v0.16.35"
 
-# XXX will require core version with metrics logging

--- a/info.yml
+++ b/info.yml
@@ -61,4 +61,5 @@ description: "Shotgun Integration in Maya"
 # Required minimum versions for this item to run
 requires_shotgun_version:
 requires_core_version: "v0.16.35"
- 
+
+# XXX will require core version with metrics logging


### PR DESCRIPTION
The call logs the metric internally and ignores any errors. This prevents the need to force the engine's users to update to a new core that supports metrics. When a supported core is updated, the metric will be logged.