### PR TITLE
#37277 Support for site context

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -297,11 +297,6 @@ class MayaEngine(tank.platform.Engine):
         except:
             # ignore all errors. ex: using a core that doesn't support metrics
             pass
-        
-        if self.context.project is None:
-            # must have at least a project in the context to even start!
-            raise tank.TankError("The engine needs at least a project in the context "
-                                 "in order to start! Your context: %s" % self.context)
 
         # Set the Maya project based on config
         self._set_project()


### PR DESCRIPTION
This removes a previous in the maya engine to ensure that at least a project context existed at startup. This check seems unnecessary and prevents the maya engine from starting up in a site-mode plugin setup. I think it was there to ensure that a maya project was always set by the engine - but we loosened that restriction a long time ago and the maya engine often runs with no project set. So I think it should be ok to just drop this check.

Need to run this through the automated QA before we merge with master.