### PR TITLE
#34893: Run toolkit manager bootstrap logic in a background thread. (merges into develop/plugin)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -28,3 +28,6 @@ pip-log.txt
 
 # PyCharm project settings
 .idea
+
+# Max OS X Desktop Services Store files
+.DS_Store

--- a/plugins/basic/plug-ins/shotgun.py
+++ b/plugins/basic/plug-ins/shotgun.py
@@ -63,9 +63,11 @@ def initializePlugin(mobject):
     # displayed in Maya Plug-in Information window.
 
     # Set the plug-in vendor name and version number to display in Maya Plug-in Information window.
-    plugin = OpenMaya2.MFnPlugin(mobject,
-                                 vendor="%s, %s" % (manifest.author, manifest.organization),
-                                 version=manifest.version)
+    plugin = OpenMaya2.MFnPlugin(
+                 mobject,
+                 vendor="%s, %s" % (manifest.author, manifest.organization),
+                 version=manifest.version
+             )
 
     # Register all the plug-in custom commands.
     for cmd_class in PLUGIN_CMD_LIST:

--- a/plugins/basic/python/tk_maya_basic/plugin_logging.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logging.py
@@ -9,7 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 import logging
-import time
 
 import maya.api.OpenMaya as OpenMaya2  # Python API 2.0
 import maya.utils
@@ -29,13 +28,11 @@ class PluginLoggingHandler(logging.Handler):
 
         super(PluginLoggingHandler, self).__init__()
 
-        # Set the handler to use a standard message format similar to the one used by the Maya engine.
-        logging_format = "%s: %s" % (plugin_name, "%(message)s")
-        self.setFormatter(logging.Formatter(logging_format))
+        self._plugin_name = plugin_name
 
-        # Time stamp used when logging debug messages.
-        # Initialized with the current time for lack of a better value.
-        self._last_debug_msg_time = time.time()
+        # Set the handler to use a standard message format similar to the one used by the engine.
+        logging_format = "Shotgun [%(levelname)s %(basename)s]: %(message)s"
+        self.setFormatter(logging.Formatter(logging_format))
 
     def emit(self, record):
         """
@@ -46,26 +43,19 @@ class PluginLoggingHandler(logging.Handler):
         :param record: Logging record to display in Maya script editor.
         """
 
+        # Set the logging format basename to be the plug-in name.
+        record.basename = self._plugin_name
+
         # Give a standard format to the message.
         msg = self.format(record)
 
         # Display the message in Maya script editor in a thread safe manner.
-        # The overall message format is similar to the one used by the Maya engine.
-        if record.levelno < logging.INFO:
-            # Time stamp the messagde with the elapsed time since the last display debug call.
-            current_time = time.time()
-            msg = "Shotgun Debug [%0.3fs]: %s" % (current_time-self._last_debug_msg_time, msg)
-            maya.utils.executeInMainThreadWithResult(OpenMaya2.MGlobal.displayInfo, msg)
-            self._last_debug_msg_time = current_time
 
-        elif record.levelno < logging.WARNING:
-            msg = "Shotgun: %s" % msg
-            maya.utils.executeInMainThreadWithResult(OpenMaya2.MGlobal.displayInfo, msg)
-
+        if record.levelno < logging.WARNING:
+            fct = OpenMaya2.MGlobal.displayInfo
         elif record.levelno < logging.ERROR:
-            msg = "Shotgun: %s" % msg
-            maya.utils.executeInMainThreadWithResult(OpenMaya2.MGlobal.displayWarning, msg)
-
+            fct = OpenMaya2.MGlobal.displayWarning
         else:
-            msg = "Shotgun: %s" % msg
-            maya.utils.executeInMainThreadWithResult(OpenMaya2.MGlobal.displayError, msg)
+            fct = OpenMaya2.MGlobal.displayError
+
+        maya.utils.executeInMainThreadWithResult(fct, msg)

--- a/plugins/basic/python/tk_maya_basic/plugin_logging.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logging.py
@@ -26,7 +26,8 @@ class PluginLoggingHandler(logging.Handler):
         :param plugin_name: Plug-in name to include in the standard message format.
         """
 
-        super(PluginLoggingHandler, self).__init__()
+        # Avoid using super() in order to be compatible with old-style classes found in older versions of logging.
+        logging.Handler.__init__(self)
 
         self._plugin_name = plugin_name
 

--- a/plugins/basic/python/tk_maya_basic/plugin_logic.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logic.py
@@ -18,8 +18,8 @@ import pymel.core as pm
 import sgtk
 
 from sgtk_plugin_basic import manifest
-import plugin_engine
-import plugin_logging
+from . import plugin_engine
+from . import plugin_logging
 
 from . import __name__ as PLUGIN_PACKAGE_NAME
 
@@ -143,6 +143,9 @@ def _handle_bootstrap_completed(engine):
     # Hide the progress bar.
     _hide_progress_bar()
 
+    # Report completion of the bootstrap.
+    standalone_logger.info("Shotgun initialization completed.")
+
     # Add a logout menu item to the engine context menu.
     sgtk.platform.current_engine().register_command(
         ITEM_LABEL_LOGOUT,
@@ -165,7 +168,7 @@ def _handle_bootstrap_failed(phase, exception):
     # Needed global to re-import the toolkit core.
     global sgtk
 
-    if phase == sgtk.bootstrap.ToolkitManager.ENGINE_STARTUP_PHASE:
+    if phase is None or phase == sgtk.bootstrap.ToolkitManager.ENGINE_STARTUP_PHASE:
         # Re-import the toolkit core to ensure usage of a swapped in version.
         import sgtk
 
@@ -173,7 +176,7 @@ def _handle_bootstrap_failed(phase, exception):
     _hide_progress_bar()
 
     # Report the encountered exception.
-    standalone_logger.error("Bootstrapping %s failed: %s" % (manifest.engine_name, exception))
+    standalone_logger.error("Shotgun initialization failed: %s" % exception)
 
     # Clear the user's credentials to log him/her out.
     sgtk.authentication.ShotgunAuthenticator().clear_default_user()


### PR DESCRIPTION
Same as #19 but merging into `develop/plugin` instead of master.