### PR TITLE
For #38957, implemented engine specific SofwareLauncher

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -10,6 +10,7 @@
 
 import os
 import sys
+import re
 import glob
 import subprocess
 import xml.etree.ElementTree as XML_ET
@@ -46,7 +47,7 @@ class MayaLauncher(SoftwareLauncher):
             # Look for executables in paths formerly specified by the
             # default configuration paths.yml file.
             sw_versions = _default_path_software_versions(
-                self._logger, versions, display_name, icon
+                self.logger, versions, display_name, icon
             )
         if not sw_versions:
             self.logger.info(
@@ -156,7 +157,6 @@ def _synergy_config_files():
 
     return synergy_configs
 
-
 def _synergy_software_versions(logger, versions=None, display_name=None, icon=None):
     """
     Creates SoftwareVersion instances based on the Synergy configuration
@@ -214,7 +214,7 @@ def _synergy_software_versions(logger, versions=None, display_name=None, icon=No
 
         if versions and synergy_data["NumericVersion"] not in versions:
             # If this version isn't in the list of requested versions, skip it.
-            logger.debug("Skipping Maya version %s ..." % synergy_data["NumericVersion"])
+            logger.debug("Skipping Maya Synergy version %s ..." % synergy_data["NumericVersion"])
             continue
 
         exec_path = synergy_data["ExecutablePath"]
@@ -314,6 +314,11 @@ def _default_path_software_versions(logger, versions=None, display_name=None, ic
                 # Parse the default version from the display name determined from
                 # the version output.
                 default_version = default_display.lower().replace("maya", "").strip()
+
+            if versions and default_version not in versions:
+                # If this version isn't in the list of requested versions, skip it.
+                logger.debug("Skipping Maya default version %s ..." % default_version)
+                continue
 
             if sys.platform == "darwin" and "Maya.app" in exec_path:
                 # There seems to be an anomoly with launching Maya from the

--- a/startup.py
+++ b/startup.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import sys
+import sgtk
+import xml.etree.ElementTree as XET
+
+from sgtk.platform import SoftwareLauncher, SoftwareVersion, LaunchInformation
+
+class MayaLauncher(SoftwareLauncher):
+    """
+    Handles launching Maya in an engine-agnostic manner.
+    """
+
+    def synergy_paths(self):
+        """
+        Override base class definition to restrict list of Synergy
+        Config files to be Maya-specific
+        """
+        if self._synergy_paths is None:
+            # Let the parent class deal with finding the files
+            all_paths = SoftwareLauncher.synergy_paths(self)
+            # Now pick out the specific ones for Maya.
+            self._synergy_paths = [
+                p for p in all_paths if os.path.basename(p).startswith("Maya")
+            ]
+        return self._synergy_paths
+
+    def scan_software(self, versions=None):
+        """
+        Performs a scan for software installations.
+
+        :param versions: List of strings representing versions
+                         to search for. If set to None, search
+                         for all versions. A version string is
+                         DCC-specific but could be something
+                         like "2017", "6.3v7" or "1.2.3.52"
+        :returns: List of :class:`SoftwareVersion` instances
+        """
+        sw_versions = []
+        for synergy_cfg in self.synergy_paths():
+            swv = self._software_version_from_synergy(synergy_cfg)
+            if not swv:
+                self.logger.debug(
+                    "Could not create SoftwareVersion from Synergy config '%s'" %
+                    (synergy_cfg)
+                )
+                continue
+            if versions and isinstance(versions, list) and str(swv.version) not in versions:
+                self.logger.debug(
+                    "Resolved version for Synergy config '%s' [%s] not found "
+                    "in specified list of versions : %s" %
+                    (synergy_cfg, swv.version, versions)
+                )
+                continue
+            sw_versions.append(swv)
+
+        [self._customize_software_version(swv) for swv in sw_versions]
+
+        return sw_versions
+
+    def resolve_software(self, sw_path):
+        """
+        Resolve a software instance for a given DCC path
+
+        :param path:
+        :returns: SoftwareVersion instance
+        """
+        synergy_data = self._synergy_data_from_executable(sw_path)
+        if not synergy_data:
+            return None
+
+        sw_version = self._sofware_version_from_synergy(syn_data=synergy_data)
+        return self._customize_software_version(sw_version)
+
+    def prepare_launch(self, software_version, args, options, file_to_open=None):
+        """
+        Prepares the given software for launch
+
+        :param software_version: Software Version to launch
+        :param args: Command line arguments as strings
+        :param options: DCC specific options to pass
+        :param file_to_open: (Optional) Full path name of a file to open on launch
+        :returns: LaunchInformation instance
+        """
+        clean_env = os.environ.copy()
+        startup_path = os.path.join(self.disk_location, "startup")
+        sgtk.util.append_path_to_env_var("PYTHONPATH", startup_path)
+        os.environ["TANK_ENGINE"] = self.engine_name
+        os.environ["TANK_CONTEXT"] = sgtk.context.serialize(self.context)
+        if file_to_open:
+            os.environ["TANK_FILE_TO_OPEN"] = file_to_open
+
+        launch_info = LaunchInformation(
+            software_version.path, args, os.environ.copy(),
+        )
+        os.environ.clear()
+        os.environ.update(clean_env)
+
+        return launch_info
+
+    def _icon_from_executable(self, exec_path):
+        """
+        Find the application icon based on the executable path and
+        current platform.
+
+        :param exec_path: Full path to the executable
+        :returns: Full path to application icon as a string or None.
+        """
+        icon_base_path = ""
+        if sys.platform == "darwin" and "Maya.app" in exec_path:
+            icon_base_path = os.path.join(
+                "".join(exec_path.partition("Maya.app")[0:2]),
+                "Contents"
+            )
+
+        elif sys.platform in ["win32", "linux2"] and "bin" in exec_path:
+            icon_base_path = "".join(exec_path.partition("bin")[0:1])
+
+        icon_path = os.path.join(icon_base_path, "icons", "mayaico.png")
+        return icon_path if os.path.exists(icon_path) else None
+
+    def _customize_software_version(self, sw_version):
+        """
+        Update SoftwareVersions retrieved from the parent class
+        with Maya specific information.
+
+        :param sw_version: SoftwareVersion instance to be updated.
+        """
+        if not sw_version:
+            # There's nothing to do
+            return sw_version
+
+        # Set the default icon
+        sw_version.icon = self._icon_from_executable(sw_version.path)
+
+        if sys.platform  == "darwin" and "Maya.app" in sw_version.path:
+            # There seems to be an anomoly with launching Maya from the
+            # full executable path on MacOS. Everything behaves nicer if
+            # Maya is launched from the bundle Maya.app directory instead.
+            sw_version.path = "".join(sw_version.path.partition("Maya.app")[0:2])
+

--- a/startup.py
+++ b/startup.py
@@ -10,31 +10,19 @@
 
 import os
 import sys
-import sgtk
-import xml.etree.ElementTree as XET
+import glob
+import subprocess
+import xml.etree.ElementTree as XML_ET
 
+import sgtk
+from sgtk import TankError
 from sgtk.platform import SoftwareLauncher, SoftwareVersion, LaunchInformation
 
 class MayaLauncher(SoftwareLauncher):
     """
-    Handles launching Maya in an engine-agnostic manner.
+    Handles launching Maya without having an active engine.
     """
-
-    def synergy_paths(self):
-        """
-        Override base class definition to restrict list of Synergy
-        Config files to be Maya-specific
-        """
-        if self._synergy_paths is None:
-            # Let the parent class deal with finding the files
-            all_paths = SoftwareLauncher.synergy_paths(self)
-            # Now pick out the specific ones for Maya.
-            self._synergy_paths = [
-                p for p in all_paths if os.path.basename(p).startswith("Maya")
-            ]
-        return self._synergy_paths
-
-    def scan_software(self, versions=None):
+    def scan_software(self, versions=None, display_name=None, icon=None):
         """
         Performs a scan for software installations.
 
@@ -43,108 +31,305 @@ class MayaLauncher(SoftwareLauncher):
                          for all versions. A version string is
                          DCC-specific but could be something
                          like "2017", "6.3v7" or "1.2.3.52"
+        :param display_name: (optional) Specify label to use for all
+                             SoftwareVersions found.
+        :param icon: (optional) Specify icon to use for all
+                     SoftwareVersions found.
+
         :returns: List of :class:`SoftwareVersion` instances
         """
-        sw_versions = []
-        for synergy_cfg in self.synergy_paths():
-            swv = self._software_version_from_synergy(synergy_cfg)
-            if not swv:
-                self.logger.debug(
-                    "Could not create SoftwareVersion from Synergy config '%s'" %
-                    (synergy_cfg)
-                )
-                continue
-            if versions and isinstance(versions, list) and str(swv.version) not in versions:
-                self.logger.debug(
-                    "Resolved version for Synergy config '%s' [%s] not found "
-                    "in specified list of versions : %s" %
-                    (synergy_cfg, swv.version, versions)
-                )
-                continue
-            sw_versions.append(swv)
+        # First look for executables using the Autodesk Synergy registry.
+        sw_versions = _synergy_software_versions(
+            self.logger, versions, display_name, icon
+        )
+        if not sw_versions:
+            # Look for executables in paths formerly specified by the
+            # default configuration paths.yml file.
+            sw_versions = _default_path_software_versions(
+                self._logger, versions, display_name, icon
+            )
+        if not sw_versions:
+            self.logger.info(
+                "Unable to determine available SoftwareVersions for engine %s" %
+                self.engine_name
+            )
+            return []
 
-        [self._customize_software_version(swv) for swv in sw_versions]
+        return  sw_versions
 
-        return sw_versions
 
-    def resolve_software(self, sw_path):
-        """
-        Resolve a software instance for a given DCC path
-
-        :param path:
-        :returns: SoftwareVersion instance
-        """
-        synergy_data = self._synergy_data_from_executable(sw_path)
-        if not synergy_data:
-            return None
-
-        sw_version = self._sofware_version_from_synergy(syn_data=synergy_data)
-        return self._customize_software_version(sw_version)
-
-    def prepare_launch(self, software_version, args, options, file_to_open=None):
+    def prepare_launch(self, exec_path, args, options, file_to_open=None):
         """
         Prepares the given software for launch
 
-        :param software_version: Software Version to launch
+        :param exec_path: Path to DCC executable to launch
         :param args: Command line arguments as strings
         :param options: DCC specific options to pass
         :param file_to_open: (Optional) Full path name of a file to open on launch
+
         :returns: LaunchInformation instance
         """
-        clean_env = os.environ.copy()
+        required_env = {}
         startup_path = os.path.join(self.disk_location, "startup")
         sgtk.util.append_path_to_env_var("PYTHONPATH", startup_path)
-        os.environ["TANK_ENGINE"] = self.engine_name
-        os.environ["TANK_CONTEXT"] = sgtk.context.serialize(self.context)
+        required_env["PYTHONPATH"] = os.environ["PYTHONPATH"]
+        required_env["TANK_ENGINE"] = self.engine_name
+        required_env["TANK_CONTEXT"] = sgtk.context.serialize(self.context)
         if file_to_open:
-            os.environ["TANK_FILE_TO_OPEN"] = file_to_open
+            required_env["TANK_FILE_TO_OPEN"] = file_to_open
 
-        launch_info = LaunchInformation(
-            software_version.path, args, os.environ.copy(),
+        return LaunchInformation(exec_path, args, required_env)
+
+
+def _icon_from_executable(exec_path):
+    """
+    Find the application icon based on the executable path and
+    current platform.
+
+    :param exec_path: Full path to the executable
+
+    :returns: Full path to application icon as a string or None.
+    """
+    icon_base_path = ""
+    if sys.platform == "darwin" and "Maya.app" in exec_path:
+        # e.g. /Applications/Autodesk/maya2016.5/Maya.app/Contents
+        icon_base_path = os.path.join(
+            "".join(exec_path.partition("Maya.app")[0:2]),
+            "Contents"
         )
-        os.environ.clear()
-        os.environ.update(clean_env)
 
-        return launch_info
+    elif sys.platform in ["win32", "linux2"] and "bin" in exec_path:
+        # e.g. C:\Program Files\Autodesk\Maya2017\  or
+        #      /usr/autodesk/maya2017/
+        icon_base_path = "".join(exec_path.partition("bin")[0:1])
 
-    def _icon_from_executable(self, exec_path):
-        """
-        Find the application icon based on the executable path and
-        current platform.
+    if not icon_base_path:
+        # If no base path, no icon
+        return None
 
-        :param exec_path: Full path to the executable
-        :returns: Full path to application icon as a string or None.
-        """
-        icon_base_path = ""
-        if sys.platform == "darwin" and "Maya.app" in exec_path:
-            icon_base_path = os.path.join(
-                "".join(exec_path.partition("Maya.app")[0:2]),
-                "Contents"
+    # Append the standard icon to the base path and
+    # return that path if it exists, else None.
+    icon_path = os.path.join(icon_base_path, "icons", "mayaico.png")
+    return icon_path if os.path.exists(icon_path) else None
+
+
+def _synergy_config_files():
+    """
+    Scans the local file system using a list of search paths for
+    Autodesk Synergy Config files (.syncfg).
+
+    :returns: List of path names to Synergy Config files found
+              in the local environment
+    """
+    # Check for custom paths defined by the SYNHUB_CONFIG_PATH env var.
+    env_paths = os.environ.get("SYNHUB_CONFIG_PATH")
+    search_paths = []
+    if isinstance(env_paths, basestring):
+        # This can be a list of directories and/or files.
+        search_paths = env_paths.split(os.pathsep)
+
+    # Check the platfom-specific default installation path
+    # if no paths were set in the environment
+    elif sys.platform == "darwin":
+        search_paths = ["/Applications/Autodesk/Synergy/"]
+    elif sys.platform == "win32":
+        search_paths = ["C:\\ProgramData\\Autodesk\\Synergy\\"]
+    elif sys.platform == "linux2":
+        search_paths = ["/opt/Autodesk/Synergy/"]
+    else:
+        return search_paths
+
+    synergy_configs = []
+    for search_path in search_paths:
+        if os.path.isdir(search_path):
+            # Get the list of *.syncfg files in this directory
+            synergy_configs.extend([
+                os.path.join(search_path, f) for f in os.listdir(search_path)
+                if f.startswith("Maya") and f.endswith(".syncfg")
+            ])
+
+        elif os.path.isfile(search_path):
+            file_name = os.path.basename(search_path)
+            if file_name.find("Maya") > -1 and file_name.endswith(".syncfg"):
+                # Add the specified Synergy Config file directly to the list of paths.
+                synergy_configs.append(search_path)
+
+    return synergy_configs
+
+
+def _synergy_software_versions(logger, versions=None, display_name=None, icon=None):
+    """
+    Creates SoftwareVersion instances based on the Synergy configuration
+    data from Synergy Config (.syncfg) files found in the local environment.
+
+    :param logger: Logger instance to use to log messages.
+    :param versions: (optional) Specific list of version numbers (as strings) to
+                     find matching executables for.
+    :param display_name: (optional) Specify label to use for all
+                         SoftwareVersions found.
+    :param icon: (optional) Specify icon to use for all
+                 SoftwareVersions found.
+
+    :returns: List of :class:`SoftwareVersion` SoftwareVersion instance.
+    """
+    # Get the list of Maya*.syncfg files in the local environment
+    configs = _synergy_config_files()
+    if not configs:
+        logger.debug(
+            "Unable to determine Autodesk Synergy paths for platform "%
+            sys.platform
+        )
+        return []
+
+    logger.debug("Found Autodesk Synergy Maya config files : %s" % configs)
+    # Determine the list of SoftwareVersion to return from the list
+    # of configurations found and the list of versions requested.
+    sw_versions = []
+    for config in configs:
+        try:
+            # Parse the Synergy Config file as XML
+            doc = XML_ET.parse(config)
+        except Exception, e:
+            raise TankError(
+                "Caught exception attempting to parse [%s] as XML.\n%s" % (config, e)
             )
 
-        elif sys.platform in ["win32", "linux2"] and "bin" in exec_path:
-            icon_base_path = "".join(exec_path.partition("bin")[0:1])
+        try:
+            # Find the <Application> element that contains the data
+            # we want.
+            app_elem = doc.getroot().find("Application")
+            if app_elem is None:
+                logger.warning(
+                    "No <Application> found in Synergy config file '%s'." % config
+                )
+                continue
 
-        icon_path = os.path.join(icon_base_path, "icons", "mayaico.png")
-        return icon_path if os.path.exists(icon_path) else None
+            # Convert the element's attribute/value pairs to a dictionary
+            synergy_data = dict(app_elem.items())
+        except Exception, e:
+            raise TankError(
+                "Caught unknown exception retrieving <Application> data from %s:\n%s" %
+                (config, e)
+            )
 
-    def _customize_software_version(self, sw_version):
-        """
-        Update SoftwareVersions retrieved from the parent class
-        with Maya specific information.
+        if versions and synergy_data["NumericVersion"] not in versions:
+            # If this version isn't in the list of requested versions, skip it.
+            logger.debug("Skipping Maya version %s ..." % synergy_data["NumericVersion"])
+            continue
 
-        :param sw_version: SoftwareVersion instance to be updated.
-        """
-        if not sw_version:
-            # There's nothing to do
-            return sw_version
-
-        # Set the default icon
-        sw_version.icon = self._icon_from_executable(sw_version.path)
-
-        if sys.platform  == "darwin" and "Maya.app" in sw_version.path:
+        exec_path = synergy_data["ExecutablePath"]
+        if sys.platform == "darwin" and "Maya.app" in exec_path:
             # There seems to be an anomoly with launching Maya from the
             # full executable path on MacOS. Everything behaves nicer if
             # Maya is launched from the bundle Maya.app directory instead.
-            sw_version.path = "".join(sw_version.path.partition("Maya.app")[0:2])
+            exec_path = "".join(exec_path.partition("Maya.app")[0:2])
 
+        # Create a SoftwareVersion from input and config data.
+        logger.debug("Creating SoftwareVersion for '%s'" % exec_path)
+        sw_versions.append(SoftwareVersion(
+            synergy_data["Name"],
+            synergy_data["NumericVersion"],
+            (display_name or synergy_data["StringVersion"]),
+            exec_path,
+            (icon or _icon_from_executable(exec_path))
+        ))
+
+    return sw_versions
+
+
+def _default_path_software_versions(logger, versions=None, display_name=None, icon=None):
+    """
+    Creates SoftwareVersion instances based on the path values used
+    in the default configuration paths.yml environment.
+
+    :param logger: Logger instance to use to log messages.
+    :param versions: (optional) Specific list of version numbers (as strings) to
+                     find matching executables for.
+    :param display_name: (optional) Specify label to use for all
+                         SoftwareVersions found.
+    :param icon: (optional) Specify icon to use for all
+                 SoftwareVersions found.
+
+    :returns: List of :class:`SoftwareVersion` SoftwareVersion instance.
+    """
+    # Determine a list of paths to search for Maya executables based
+    # on default installation path(s) for the current platform
+    search_paths = []
+    exec_paths = []
+    if sys.platform == "darwin":
+        search_paths = glob.glob("/Applications/Autodesk/maya*")
+
+    elif sys.platform == "win32":
+        search_paths = glob.glob("C:\Program Files\Autodesk\Maya*")
+
+    elif sys.platform == "linux2":
+        exec_paths.append("maya")
+
+    if search_paths:
+        for search_path in search_paths:
+            # Construct the expected executable name for this path.
+            # If it exists, add it to the list of exec_paths to check.
+            exec_path = None
+            if sys.platform == "darwin":
+                exec_path = os.path.join(search_path, "Maya.app", "Contents", "bin", "maya")
+
+            elif sys.platform == "win32":
+                exec_path = os.path.join(search_path, "bin", "maya.exe")
+
+            if exec_path and os.path.exists(exec_path):
+                exec_paths.append(exec_path)
+
+    sw_versions = []
+    sw_version_regex = "%smaya[0-9]+[.0-9]*%s" % (os.path.sep, os.path.sep)
+    if exec_paths:
+        for exec_path in exec_paths:
+            # Check to see if the version number can be parsed from the path name.
+            sw_version_search = re.search(sw_version_regex, exec_path.lower())
+            if sw_version_search is not None:
+                # Use this sub dir to determine the default display name
+                # and version for the SoftwareVersion to be created.
+                default_display = sw_version_search.group(0)[1:-1]
+                default_version = default_display.replace("maya", "")
+                default_display = "Maya %s" % default_version
+            else:
+                try:
+                    # This works, but makes the Desktop project window disappear
+                    # for some reason, which isn't very nice. Therefore, use as a
+                    # last resort.
+                    version_output = subprocess.check_output([exec_path, "-v"])
+                except OSError:
+                    logger.exception(
+                        "Could not retrieve version information from default "
+                        "executable path '%s'." % exec_path
+                    )
+                    continue
+
+                # Display and version information are contained before the first ','
+                # in the output version string.
+                default_display = version_output[0:version_output.find(",")]
+                if "2016 Extension 2 SP1" in default_display:
+                    # Update the display value to know "nicer" version numbers.
+                    default_display = default_display.replace("2016 Extension 2 SP1", "2016.5")
+
+                # Parse the default version from the display name determined from
+                # the version output.
+                default_version = default_display.lower().replace("maya", "").strip()
+
+            if sys.platform == "darwin" and "Maya.app" in exec_path:
+                # There seems to be an anomoly with launching Maya from the
+                # full executable path on MacOS. Everything behaves nicer if
+                # Maya is launched from the bundle Maya.app directory instead.
+                exec_path = "".join(exec_path.partition("Maya.app")[0:2])
+
+            # Create a SoftwareVersion using the information from executable path(s) found
+            # in default locations.
+            logger.debug("Creating SoftwareVersion for executable '%s'." % exec_path)
+            sw_versions.append(SoftwareVersion(
+                default_display.replace(" ", "_"),
+                default_version,
+                (display_name or default_display),
+                exec_path,
+                (icon or _icon_from_executable(exec_path))
+            ))
+
+    return sw_versions

--- a/startup.py
+++ b/startup.py
@@ -13,7 +13,8 @@ import sys
 import re
 import glob
 import subprocess
-import xml.etree.ElementTree as XML_ET
+
+from xml.etree import ElementTree
 
 import sgtk
 from sgtk import TankError
@@ -21,33 +22,36 @@ from sgtk.platform import SoftwareLauncher, SoftwareVersion, LaunchInformation
 
 class MayaLauncher(SoftwareLauncher):
     """
-    Handles launching Maya without having an active engine.
+    Handles launching Maya executables. Automatically starts up
+    a tk-maya engine with the current context in the new session
+    of Maya.
     """
     def scan_software(self, versions=None, display_name=None, icon=None):
         """
         Performs a scan for software installations.
 
-        :param versions: List of strings representing versions
-                         to search for. If set to None, search
-                         for all versions. A version string is
-                         DCC-specific but could be something
-                         like "2017", "6.3v7" or "1.2.3.52"
-        :param display_name: (optional) Specify label to use for all
-                             SoftwareVersions found.
-        :param icon: (optional) Specify icon to use for all
-                     SoftwareVersions found.
-
+        :param list versions: List of strings representing versions
+                              to search for. If set to None, search
+                              for all versions. A version string is
+                              DCC-specific but could be something
+                              like "2017", "6.3v7" or "1.2.3.52".
+        :param str display_name : (optional) Name to use in graphical
+                                  displays to describe the
+                                  SoftwareVersions that were found.
+        :param icon: (optional) Path to a 256x256 (or smaller) png file
+                     to use in graphical displays for every SoftwareVersion
+                     found.
         :returns: List of :class:`SoftwareVersion` instances
         """
         # First look for executables using the Autodesk Synergy registry.
-        sw_versions = _synergy_software_versions(
-            self.logger, versions, display_name, icon
+        sw_versions = self._synergy_software_versions(
+            versions, display_name, icon
         )
         if not sw_versions:
             # Look for executables in paths formerly specified by the
             # default configuration paths.yml file.
-            sw_versions = _default_path_software_versions(
-                self.logger, versions, display_name, icon
+            sw_versions = self._default_path_software_versions(
+                versions, display_name, icon
             )
         if not sw_versions:
             self.logger.info(
@@ -56,69 +60,299 @@ class MayaLauncher(SoftwareLauncher):
             )
             return []
 
-        return  sw_versions
+        return sw_versions
 
-
-    def prepare_launch(self, exec_path, args, options, file_to_open=None):
+    def prepare_launch(self, exec_path, args, file_to_open=None):
         """
-        Prepares the given software for launch
+        Prepares the given software for launch.
 
-        :param exec_path: Path to DCC executable to launch
-        :param args: Command line arguments as strings
-        :param options: DCC specific options to pass
-        :param file_to_open: (Optional) Full path name of a file to open on launch
-
-        :returns: LaunchInformation instance
+        :param str exec_path: Path to DCC executable to launch.
+        :param str args: Command line arguments as strings.
+        :param str file_to_open: (optional) Full path name of a file to open on launch.
+        :returns: :class:`LaunchInformation` instance
         """
         required_env = {}
         startup_path = os.path.join(self.disk_location, "startup")
         sgtk.util.append_path_to_env_var("PYTHONPATH", startup_path)
         required_env["PYTHONPATH"] = os.environ["PYTHONPATH"]
-        required_env["TANK_ENGINE"] = self.engine_name
-        required_env["TANK_CONTEXT"] = sgtk.context.serialize(self.context)
+        required_env["SGTK_ENGINE"] = self.engine_name
+        required_env["SGTK_CONTEXT"] = sgtk.context.serialize(self.context)
         if file_to_open:
-            required_env["TANK_FILE_TO_OPEN"] = file_to_open
+            required_env["SGTK_FILE_TO_OPEN"] = file_to_open
 
         return LaunchInformation(exec_path, args, required_env)
 
+    ##########################################################################################
+    # private methods
 
-def _icon_from_executable(exec_path):
-    """
-    Find the application icon based on the executable path and
-    current platform.
+    def _icon_from_executable(self, exec_path):
+        """
+        Find the application icon based on the executable path and
+        current platform.
 
-    :param exec_path: Full path to the executable
+        :param exec_path: Full path to the executable.
 
-    :returns: Full path to application icon as a string or None.
-    """
-    icon_base_path = ""
-    if sys.platform == "darwin" and "Maya.app" in exec_path:
-        # e.g. /Applications/Autodesk/maya2016.5/Maya.app/Contents
-        icon_base_path = os.path.join(
-            "".join(exec_path.partition("Maya.app")[0:2]),
-            "Contents"
+        :returns: Full path to application icon as a string or None.
+        """
+        self.logger.debug(
+            "Looking for Application icon for executable '%s' ..." %
+            exec_path
+        )
+        icon_base_path = ""
+        if sys.platform == "darwin" and "Maya.app" in exec_path:
+            # e.g. /Applications/Autodesk/maya2016.5/Maya.app/Contents
+            icon_base_path = os.path.join(
+                "".join(exec_path.partition("Maya.app")[0:2]),
+                "Contents"
+            )
+
+        elif sys.platform in ["win32", "linux2"] and "bin" in exec_path:
+            # e.g. C:\Program Files\Autodesk\Maya2017\  or
+            #      /usr/autodesk/maya2017/
+            icon_base_path = "".join(exec_path.partition("bin")[0:1])
+
+        if not icon_base_path:
+            # If no base path, no icon
+            self.logger.debug(
+                "Could not resolve icon base path for executable '%s'." %
+                exec_path
+            )
+            return None
+
+        # Append the standard icon to the base path and
+        # return that path if it exists, else None.
+        icon_path = os.path.join(icon_base_path, "icons", "mayaico.png")
+        if not os.path.exists(icon_path):
+            self.logger.debug(
+                "Icon path '%s' resolved from executable '%s' does not exist!" %
+                (icon_path, exec_path)
+            )
+            return None
+
+        # Record what the resolved icon path was.
+        self.logger.debug("Resolved icon path '%s' from input executable '%s'." %
+            (icon_path, exec_path)
+        )
+        return icon_path
+
+    def _synergy_software_versions(
+            self, versions=None, display_name=None, icon=None
+        ):
+        """
+        Creates SoftwareVersion instances based on the Synergy configuration
+        data from Synergy Config (.syncfg) files found in the local environment.
+
+        :param list versions: (optional) List of strings representing
+                              versions to search for. If set to None,
+                              search for all versions. A version string
+                              is DCC-specific but could be something
+                              like "2017", "6.3v7" or "1.2.3.52".
+        :param str display_name : (optional) Name to use in graphical
+                                  displays to describe the
+                                  SoftwareVersions that were found.
+        :param icon: (optional) Path to a 256x256 (or smaller) png file
+                     to use in graphical displays for every SoftwareVersion
+                     found.
+        :returns: List of :class:`SoftwareVersion` instances
+        """
+        # Get the list of Maya*.syncfg files in the local environment
+        configs = _synergy_config_files("Maya")
+        if not configs:
+            self.logger.debug(
+                "Unable to determine Autodesk Synergy paths for platform "%
+                sys.platform
+            )
+            return []
+        self.logger.debug("Found (%d) Autodesk Synergy Maya config files." %
+            len(configs)
         )
 
-    elif sys.platform in ["win32", "linux2"] and "bin" in exec_path:
-        # e.g. C:\Program Files\Autodesk\Maya2017\  or
-        #      /usr/autodesk/maya2017/
-        icon_base_path = "".join(exec_path.partition("bin")[0:1])
+        # Determine the list of SoftwareVersion to return from the list
+        # of configurations found and the list of versions requested.
+        sw_versions = []
+        for config in configs:
+            self.logger.debug("Parsing Synergy config '%s' ..." % config)
+            try:
+                # Parse the Synergy Config file as XML
+                doc = ElementTree.parse(config)
+            except Exception, e:
+                raise TankError(
+                    "Caught exception attempting to parse [%s] as XML.\n%s" %
+                    (config, e)
+                )
 
-    if not icon_base_path:
-        # If no base path, no icon
-        return None
+            try:
+                # Find the <Application> element that contains the data
+                # we want.
+                app_elem = doc.getroot().find("Application")
+                if app_elem is None:
+                    self.logger.warning(
+                        "No <Application> found in Synergy config file '%s'." %
+                        config
+                    )
+                    continue
 
-    # Append the standard icon to the base path and
-    # return that path if it exists, else None.
-    icon_path = os.path.join(icon_base_path, "icons", "mayaico.png")
-    return icon_path if os.path.exists(icon_path) else None
+                # Convert the element's attribute/value pairs to a dictionary
+                synergy_data = dict(app_elem.items())
+                self.logger.debug("Synergy data from config : %s" % synergy_data)
+            except Exception, e:
+                raise TankError(
+                    "Caught unknown exception retrieving <Application> data "
+                    "from %s:\n%s" % (config, e)
+                )
+
+            if versions and synergy_data["NumericVersion"] not in versions:
+                # If this version isn't in the list of requested versions, skip it.
+                self.logger.debug("Skipping Maya Synergy version %s ..." %
+                    synergy_data["NumericVersion"]
+                )
+                continue
+
+            exec_path = synergy_data["ExecutablePath"]
+            if sys.platform == "darwin" and "Maya.app" in exec_path:
+                # There seems to be an anomoly with launching Maya from the
+                # full executable path on MacOS. Everything behaves nicer if
+                # Maya is launched from the bundle Maya.app directory instead.
+                exec_path = "".join(exec_path.partition("Maya.app")[0:2])
+
+            # Create a SoftwareVersion from input and config data.
+            self.logger.debug("Creating SoftwareVersion for '%s'" % exec_path)
+            sw_versions.append(SoftwareVersion(
+                synergy_data["NumericVersion"],
+                (display_name or synergy_data["StringVersion"]),
+                exec_path,
+                (icon or self._icon_from_executable(exec_path))
+            ))
+
+        return sw_versions
+
+    def _default_path_software_versions(
+            self, versions=None, display_name=None, icon=None
+        ):
+        """
+        Creates SoftwareVersion instances based on the path values used
+        in the default configuration paths.yml environment.
+
+        :param list versions: (optional) List of strings representing
+                              versions to search for. If set to None,
+                              search for all versions. A version string
+                              is DCC-specific but could be something
+                              like "2017", "6.3v7" or "1.2.3.52"
+        :param str display_name : (optional) Name to use in graphical
+                                  displays to describe the
+                                  SoftwareVersions that were found.
+        :param icon: (optional) Path to a 256x256 (or smaller) png file
+                     to use in graphical displays for every SoftwareVersion
+                     found.
+        :returns: List of :class:`SoftwareVersion` instances
+        """
+        # Determine a list of paths to search for Maya executables based
+        # on default installation path(s) for the current platform
+        search_paths = []
+        exec_paths = []
+        if sys.platform == "darwin":
+            search_paths = glob.glob("/Applications/Autodesk/maya*")
+
+        elif sys.platform == "win32":
+            search_paths = glob.glob("C:\Program Files\Autodesk\Maya*")
+
+        elif sys.platform == "linux2":
+            exec_paths.append("maya")
+
+        if search_paths:
+            for search_path in search_paths:
+                # Construct the expected executable name for this path.
+                # If it exists, add it to the list of exec_paths to check.
+                exec_path = None
+                if sys.platform == "darwin":
+                    exec_path = os.path.join(search_path, "Maya.app", "Contents", "bin", "maya")
+
+                elif sys.platform == "win32":
+                    exec_path = os.path.join(search_path, "bin", "maya.exe")
+
+                if exec_path and os.path.exists(exec_path):
+                    exec_paths.append(exec_path)
+
+        sw_versions = []
+        if exec_paths:
+            for exec_path in exec_paths:
+                # Check to see if the version number can be parsed from the path name.
+                path_sw_versions = [p.lower() for p in exec_path.split(os.path.sep)
+                    if re.match("maya[0-9]+[.0-9]*$", p.lower()) is not None
+                ]
+                if path_sw_versions:
+                    # Use this sub dir to determine the default display name
+                    # and version for the SoftwareVersion to be created.
+                    default_display = path_sw_versions[0]
+                    default_version = default_display.replace("maya", "")
+                    default_display = "Maya %s" % default_version
+                    self.logger.debug(
+                        "Resolved version '%s' from executable '%s'." %
+                        (default_version, exec_path)
+                    )
+                else:
+                    try:
+                        # This works, but makes the Desktop project window disappear
+                        # for some reason, which isn't very nice. Therefore, use as a
+                        # last resort.
+                        version_output = subprocess.check_output([exec_path, "-v"])
+                    except OSError:
+                        self.logger.exception(
+                            "Could not retrieve version information from default "
+                            "executable path '%s'." % exec_path
+                        )
+                        continue
+
+                    # Display and version information are contained before the first ','
+                    # in the output version string.
+                    default_display = version_output[0:version_output.find(",")]
+                    if "2016 Extension 2 SP1" in default_display:
+                        # Update the display value to know "nicer" version numbers.
+                        default_display = default_display.replace("2016 Extension 2 SP1", "2016.5")
+
+                    # Parse the default version from the display name determined from
+                    # the version output.
+                    default_version = default_display.lower().replace("maya", "").strip()
+                    self.logger.debug(
+                        "Resolved version '%s' from version output '%s'" %
+                        (default_version, version_output)
+                    )
+
+                if versions and default_version not in versions:
+                    # If this version isn't in the list of requested versions, skip it.
+                    self.logger.debug("Skipping Maya default version %s ..." %
+                        default_version
+                    )
+                    continue
+
+                if sys.platform == "darwin" and "Maya.app" in exec_path:
+                    # There seems to be an anomoly with launching Maya from the
+                    # full executable path on MacOS. Everything behaves nicer if
+                    # Maya is launched from the bundle Maya.app directory instead.
+                    exec_path = "".join(exec_path.partition("Maya.app")[0:2])
+
+                # Create a SoftwareVersion using the information from executable
+                # path(s) found in default locations.
+                self.logger.debug("Creating SoftwareVersion for executable '%s'." %
+                    exec_path
+                )
+                sw_versions.append(SoftwareVersion(
+                    default_version,
+                    (display_name or default_display),
+                    exec_path,
+                    (icon or self._icon_from_executable(exec_path))
+                ))
+
+        return sw_versions
 
 
-def _synergy_config_files():
+def _synergy_config_files(config_match=None):
     """
     Scans the local file system using a list of search paths for
     Autodesk Synergy Config files (.syncfg).
 
+    :param str config_prefix: Substring resolved Synergy config
+                              file should start with.
     :returns: List of path names to Synergy Config files found
               in the local environment
     """
@@ -132,209 +366,43 @@ def _synergy_config_files():
     # Check the platfom-specific default installation path
     # if no paths were set in the environment
     elif sys.platform == "darwin":
-        search_paths = ["/Applications/Autodesk/Synergy/"]
+        search_paths = ["/Applications/Autodesk/Synergy"]
     elif sys.platform == "win32":
-        search_paths = ["C:\\ProgramData\\Autodesk\\Synergy\\"]
+        search_paths = ["C:\\ProgramData\\Autodesk\\Synergy"]
     elif sys.platform == "linux2":
-        search_paths = ["/opt/Autodesk/Synergy/"]
+        search_paths = ["/opt/Autodesk/Synergy"]
     else:
         return search_paths
 
+    # Find the Synergy config files from the list of paths
+    # to search. Filter by files that start with config_prefix
+    # if specified.
     synergy_configs = []
     for search_path in search_paths:
         if os.path.isdir(search_path):
-            # Get the list of *.syncfg files in this directory
-            synergy_configs.extend([
-                os.path.join(search_path, f) for f in os.listdir(search_path)
-                if f.startswith("Maya") and f.endswith(".syncfg")
-            ])
-
-        elif os.path.isfile(search_path):
-            file_name = os.path.basename(search_path)
-            if file_name.find("Maya") > -1 and file_name.endswith(".syncfg"):
-                # Add the specified Synergy Config file directly to the list of paths.
-                synergy_configs.append(search_path)
-
-    return synergy_configs
-
-def _synergy_software_versions(logger, versions=None, display_name=None, icon=None):
-    """
-    Creates SoftwareVersion instances based on the Synergy configuration
-    data from Synergy Config (.syncfg) files found in the local environment.
-
-    :param logger: Logger instance to use to log messages.
-    :param versions: (optional) Specific list of version numbers (as strings) to
-                     find matching executables for.
-    :param display_name: (optional) Specify label to use for all
-                         SoftwareVersions found.
-    :param icon: (optional) Specify icon to use for all
-                 SoftwareVersions found.
-
-    :returns: List of :class:`SoftwareVersion` SoftwareVersion instance.
-    """
-    # Get the list of Maya*.syncfg files in the local environment
-    configs = _synergy_config_files()
-    if not configs:
-        logger.debug(
-            "Unable to determine Autodesk Synergy paths for platform "%
-            sys.platform
-        )
-        return []
-
-    logger.debug("Found Autodesk Synergy Maya config files : %s" % configs)
-    # Determine the list of SoftwareVersion to return from the list
-    # of configurations found and the list of versions requested.
-    sw_versions = []
-    for config in configs:
-        try:
-            # Parse the Synergy Config file as XML
-            doc = XML_ET.parse(config)
-        except Exception, e:
-            raise TankError(
-                "Caught exception attempting to parse [%s] as XML.\n%s" % (config, e)
-            )
-
-        try:
-            # Find the <Application> element that contains the data
-            # we want.
-            app_elem = doc.getroot().find("Application")
-            if app_elem is None:
-                logger.warning(
-                    "No <Application> found in Synergy config file '%s'." % config
-                )
-                continue
-
-            # Convert the element's attribute/value pairs to a dictionary
-            synergy_data = dict(app_elem.items())
-        except Exception, e:
-            raise TankError(
-                "Caught unknown exception retrieving <Application> data from %s:\n%s" %
-                (config, e)
-            )
-
-        if versions and synergy_data["NumericVersion"] not in versions:
-            # If this version isn't in the list of requested versions, skip it.
-            logger.debug("Skipping Maya Synergy version %s ..." % synergy_data["NumericVersion"])
-            continue
-
-        exec_path = synergy_data["ExecutablePath"]
-        if sys.platform == "darwin" and "Maya.app" in exec_path:
-            # There seems to be an anomoly with launching Maya from the
-            # full executable path on MacOS. Everything behaves nicer if
-            # Maya is launched from the bundle Maya.app directory instead.
-            exec_path = "".join(exec_path.partition("Maya.app")[0:2])
-
-        # Create a SoftwareVersion from input and config data.
-        logger.debug("Creating SoftwareVersion for '%s'" % exec_path)
-        sw_versions.append(SoftwareVersion(
-            synergy_data["Name"],
-            synergy_data["NumericVersion"],
-            (display_name or synergy_data["StringVersion"]),
-            exec_path,
-            (icon or _icon_from_executable(exec_path))
-        ))
-
-    return sw_versions
-
-
-def _default_path_software_versions(logger, versions=None, display_name=None, icon=None):
-    """
-    Creates SoftwareVersion instances based on the path values used
-    in the default configuration paths.yml environment.
-
-    :param logger: Logger instance to use to log messages.
-    :param versions: (optional) Specific list of version numbers (as strings) to
-                     find matching executables for.
-    :param display_name: (optional) Specify label to use for all
-                         SoftwareVersions found.
-    :param icon: (optional) Specify icon to use for all
-                 SoftwareVersions found.
-
-    :returns: List of :class:`SoftwareVersion` SoftwareVersion instance.
-    """
-    # Determine a list of paths to search for Maya executables based
-    # on default installation path(s) for the current platform
-    search_paths = []
-    exec_paths = []
-    if sys.platform == "darwin":
-        search_paths = glob.glob("/Applications/Autodesk/maya*")
-
-    elif sys.platform == "win32":
-        search_paths = glob.glob("C:\Program Files\Autodesk\Maya*")
-
-    elif sys.platform == "linux2":
-        exec_paths.append("maya")
-
-    if search_paths:
-        for search_path in search_paths:
-            # Construct the expected executable name for this path.
-            # If it exists, add it to the list of exec_paths to check.
-            exec_path = None
-            if sys.platform == "darwin":
-                exec_path = os.path.join(search_path, "Maya.app", "Contents", "bin", "maya")
-
-            elif sys.platform == "win32":
-                exec_path = os.path.join(search_path, "bin", "maya.exe")
-
-            if exec_path and os.path.exists(exec_path):
-                exec_paths.append(exec_path)
-
-    sw_versions = []
-    sw_version_regex = "%smaya[0-9]+[.0-9]*%s" % (os.path.sep, os.path.sep)
-    if exec_paths:
-        for exec_path in exec_paths:
-            # Check to see if the version number can be parsed from the path name.
-            sw_version_search = re.search(sw_version_regex, exec_path.lower())
-            if sw_version_search is not None:
-                # Use this sub dir to determine the default display name
-                # and version for the SoftwareVersion to be created.
-                default_display = sw_version_search.group(0)[1:-1]
-                default_version = default_display.replace("maya", "")
-                default_display = "Maya %s" % default_version
-            else:
-                try:
-                    # This works, but makes the Desktop project window disappear
-                    # for some reason, which isn't very nice. Therefore, use as a
-                    # last resort.
-                    version_output = subprocess.check_output([exec_path, "-v"])
-                except OSError:
-                    logger.exception(
-                        "Could not retrieve version information from default "
-                        "executable path '%s'." % exec_path
-                    )
+            for item in os.listdir(search_path):
+                if not item.endswith(".syncfg"):
+                    # Skip non Synergy config files
                     continue
 
-                # Display and version information are contained before the first ','
-                # in the output version string.
-                default_display = version_output[0:version_output.find(",")]
-                if "2016 Extension 2 SP1" in default_display:
-                    # Update the display value to know "nicer" version numbers.
-                    default_display = default_display.replace("2016 Extension 2 SP1", "2016.5")
+                if config_match and config_match not in item:
+                    # Skip Synergy config files that do not
+                    # contain the requested string
+                    continue
 
-                # Parse the default version from the display name determined from
-                # the version output.
-                default_version = default_display.lower().replace("maya", "").strip()
+                # Found a matching Synergy config file
+                synergy_configs.append(os.path.join(search_path, item))
 
-            if versions and default_version not in versions:
-                # If this version isn't in the list of requested versions, skip it.
-                logger.debug("Skipping Maya default version %s ..." % default_version)
-                continue
+        elif os.path.isfile(search_path):
+            # Determine whether this search_path is a Synergy
+            # config file and matches the specified config_prefix,
+            # if requested.
+            file_name = os.path.basename(search_path)
+            if file_name.endswith(".syncfg"):
+                if config_match:
+                    if config_match in file_name:
+                        synergy_configs.append(search_path)
+                else:
+                    synergy_configs.append(search_path)
 
-            if sys.platform == "darwin" and "Maya.app" in exec_path:
-                # There seems to be an anomoly with launching Maya from the
-                # full executable path on MacOS. Everything behaves nicer if
-                # Maya is launched from the bundle Maya.app directory instead.
-                exec_path = "".join(exec_path.partition("Maya.app")[0:2])
-
-            # Create a SoftwareVersion using the information from executable path(s) found
-            # in default locations.
-            logger.debug("Creating SoftwareVersion for executable '%s'." % exec_path)
-            sw_versions.append(SoftwareVersion(
-                default_display.replace(" ", "_"),
-                default_version,
-                (display_name or default_display),
-                exec_path,
-                (icon or _icon_from_executable(exec_path))
-            ))
-
-    return sw_versions
+    return synergy_configs

--- a/startup/userSetup.py
+++ b/startup/userSetup.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+This file is loaded automatically by Maya at startup
+It sets up the tank context and prepares the Tank Maya engine.
+"""
+
+
+import os
+import maya.OpenMaya as OpenMaya
+import maya.cmds as cmds
+
+def bootstrap_tank():
+    
+    try:
+        import tank
+    except Exception, e:
+        OpenMaya.MGlobal.displayError("Shotgun: Could not import sgtk! Disabling for now: %s" % e)
+        return
+    
+    if not "TANK_ENGINE" in os.environ:
+        OpenMaya.MGlobal.displayError("Shotgun: Missing required environment variable TANK_ENGINE.")
+        return
+    
+    engine_name = os.environ.get("TANK_ENGINE") 
+    try:
+        context = tank.context.deserialize(os.environ.get("TANK_CONTEXT"))
+    except Exception, e:
+        OpenMaya.MGlobal.displayError("Shotgun: Could not create context! Shotgun Pipeline Toolkit will be disabled. Details: %s" % e)
+        return
+        
+    try:    
+        engine = tank.platform.start_engine(engine_name, context.tank, context)
+    except Exception, e:
+        OpenMaya.MGlobal.displayError("Shotgun: Could not start engine: %s" % e)
+        return
+    
+    file_to_open = os.environ.get("TANK_FILE_TO_OPEN")
+    if file_to_open:
+        # finally open the file
+        cmds.file(file_to_open, force=True, open=True)
+
+    # clean up temp env vars
+    for var in ["TANK_ENGINE", "TANK_CONTEXT", "TANK_FILE_TO_OPEN"]:
+        if var in os.environ:
+            del os.environ[var]
+
+
+cmds.evalDeferred("bootstrap_tank()")
+

--- a/startup/userSetup.py
+++ b/startup/userSetup.py
@@ -1,58 +1,81 @@
-# Copyright (c) 2013 Shotgun Software Inc.
-# 
+# Copyright (c) 2016 Shotgun Software Inc.
+#
 # CONFIDENTIAL AND PROPRIETARY
-# 
-# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
 # Source Code License included in this distribution package. See LICENSE.
-# By accessing, using, copying or modifying this work you indicate your 
-# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 """
 This file is loaded automatically by Maya at startup
-It sets up the tank context and prepares the Tank Maya engine.
+It sets up the Toolkit context and prepares the tk-maya engine.
 """
-
 
 import os
 import maya.OpenMaya as OpenMaya
 import maya.cmds as cmds
 
-def bootstrap_tank():
-    
+def bootstrap_sgtk():
+    """
+    Parse enviornment variables for an engine name and
+    serialized Context to use to startup a Toolkit Engine
+    and environment.
+    """
+    # Verify sgtk can be loaded.
     try:
-        import tank
+        import sgtk
     except Exception, e:
-        OpenMaya.MGlobal.displayError("Shotgun: Could not import sgtk! Disabling for now: %s" % e)
+        OpenMaya.MGlobal.displayError(
+            "Shotgun: Could not import sgtk! Disabling for now: %s" % e
+        )
         return
-    
-    if not "TANK_ENGINE" in os.environ:
-        OpenMaya.MGlobal.displayError("Shotgun: Missing required environment variable TANK_ENGINE.")
+
+    # Get the name of the engine to start from the environement
+    env_engine = os.environ.get("SGTK_ENGINE")
+    if not env_engine:
+        OpenMaya.MGlobal.displayError(
+            "Shotgun: Missing required environment variable SGTK_ENGINE."
+        )
         return
-    
-    engine_name = os.environ.get("TANK_ENGINE") 
+
+    # Get the context load from the environment.
+    env_context = os.environ.get("SGTK_CONTEXT")
+    if not env_context:
+        OpenMaya.MGlobal.displayError(
+            "Shotgun: Missing required environment variable SGTK_CONTEXT."
+        )
+        return
     try:
-        context = tank.context.deserialize(os.environ.get("TANK_CONTEXT"))
+        # Deserialize the environment context
+        context = sgtk.context.deserialize(env_context)
     except Exception, e:
-        OpenMaya.MGlobal.displayError("Shotgun: Could not create context! Shotgun Pipeline Toolkit will be disabled. Details: %s" % e)
+        OpenMaya.MGlobal.displayError(
+            "Shotgun: Could not create context! Shotgun Pipeline Toolkit will "
+            "be disabled. Details: %s" % e
+        )
         return
-        
-    try:    
-        engine = tank.platform.start_engine(engine_name, context.tank, context)
+
+    try:
+        # Start up the toolkit engine from the environment data
+        engine = sgtk.platform.start_engine(env_engine, context.sgtk, context)
     except Exception, e:
-        OpenMaya.MGlobal.displayError("Shotgun: Could not start engine: %s" % e)
+        OpenMaya.MGlobal.displayError(
+            "Shotgun: Could not start engine: %s" % e
+        )
         return
-    
-    file_to_open = os.environ.get("TANK_FILE_TO_OPEN")
+
+    file_to_open = os.environ.get("SGTK_FILE_TO_OPEN")
     if file_to_open:
         # finally open the file
         cmds.file(file_to_open, force=True, open=True)
 
     # clean up temp env vars
-    for var in ["TANK_ENGINE", "TANK_CONTEXT", "TANK_FILE_TO_OPEN"]:
+    for var in ["SGTK_ENGINE", "SGTK_CONTEXT", "SGTK_FILE_TO_OPEN"]:
         if var in os.environ:
             del os.environ[var]
 
 
-cmds.evalDeferred("bootstrap_tank()")
-
+# Fire up Toolkit and the environment engine when there's time.
+cmds.evalDeferred("bootstrap_sgtk()")


### PR DESCRIPTION
Initial implementation for #38957 "auto detect maya paths" and #38959 "start up tk classic at maya app launch". Adds a MayaLauncher subclass of SoftwareLauncher to handle aspects of launching the Maya from within the Toolkit engine. Implements functionality required to launch TK classic on application launch, as tk-multi-launchapp does.