### PR TITLE
[minor] Added site warning

### DIFF
--- a/plugins/basic/python/tk_maya_basic/plugin_engine.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_engine.py
@@ -62,6 +62,8 @@ def bootstrap(sg_user, progress_callback, completed_callback, failed_callback):
                        "SHOTGUN_ENTITY_TYPE and SHOTGUN_ENTITY_ID will therefore "
                        "be ignored." % (sg_user.host, entity_type, entity_id, shotgun_site)
                        )
+        entity_type = None
+        entity_id = None
 
     if (entity_type and not entity_id) or (not entity_type and entity_id):
         logger.error("Both environment variables SHOTGUN_ENTITY_TYPE and SHOTGUN_ENTITY_ID must be provided "

--- a/plugins/basic/python/tk_maya_basic/plugin_engine.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_engine.py
@@ -48,8 +48,19 @@ def bootstrap(sg_user, progress_callback, completed_callback, failed_callback):
     manifest.initialize_manager(toolkit_mgr, PLUGIN_ROOT_PATH)
 
     # Retrieve the Shotgun entity type and id when they exist in the environment.
+    shotgun_site = os.environ.get("SHOTGUN_SITE")
     entity_type = os.environ.get("SHOTGUN_ENTITY_TYPE")
     entity_id = os.environ.get("SHOTGUN_ENTITY_ID")
+
+    # Check that the shotgun site (if set) matches the site we are currently
+    # logged in to. If not, issue a warning and ignore the entity type/id variables
+    # TODO: Handle this correctly and pop up a login dialog in case of a site mismatch
+    if shotgun_site and sg_user.host != shotgun_site:
+        logger.warning("You are currently logged in to site %s but the plugin has been "
+                       "requested to launch with context %s %s on site %s. "
+                       "This will be ignored and plugin will start up in site context "
+                       "for site %s" % (sg_user.host, entity_type, entity_id, shotgun_site, sg_user.host)
+                       )
 
     if (entity_type and not entity_id) or (not entity_type and entity_id):
         logger.error("Both environment variables SHOTGUN_ENTITY_TYPE and SHOTGUN_ENTITY_ID must be provided "

--- a/plugins/basic/python/tk_maya_basic/plugin_engine.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_engine.py
@@ -57,9 +57,10 @@ def bootstrap(sg_user, progress_callback, completed_callback, failed_callback):
     # TODO: Handle this correctly and pop up a login dialog in case of a site mismatch
     if shotgun_site and sg_user.host != shotgun_site:
         logger.warning("You are currently logged in to site %s but the plugin has been "
-                       "requested to launch with context %s %s on site %s. "
-                       "This will be ignored and plugin will start up in site context "
-                       "for site %s" % (sg_user.host, entity_type, entity_id, shotgun_site, sg_user.host)
+                       "requested to launch with context %s %s at %s. The plugin does not "
+                       "currently support switching between sites and the contents of "
+                       "SHOTGUN_ENTITY_TYPE and SHOTGUN_ENTITY_ID will therefore "
+                       "be ignored." % (sg_user.host, entity_type, entity_id, shotgun_site)
                        )
 
     if (entity_type and not entity_id) or (not entity_type and entity_id):


### PR DESCRIPTION
Adds a `SHOTGUN_SITE` environment variable alongside `SHOTGUN_ENTITY_TYPE` and `SHOTGUN_ENTITY_ID`. If `SHOTGUN_SITE` is set and not matching the site that we are currently logged in to, a warning in Maya is displayed:

```
# Warning: Shotgun [WARNING tk-maya-basic]: You are currently logged in to site
https://wintermute.shotgunstudio.com but the plugin has been requested to launch 
with context Asset 1234 at https://foo.shotgunstudio.com. The plugin does not 
currently support switching between sites and the contents of SHOTGUN_ENTITY_TYPE
and SHOTGUN_ENTITY_ID will therefore be ignored. # 
```

At some point later, we can handle the extended implementation of this where the site is switched, the user is prompted for authentication etc., but this is outside the scope of basic zero config. For now, it's useful to just get a warning.