### PR TITLE
#37575: Capture and recall Maya engine panel state in Maya 2017.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -355,7 +355,7 @@ class MayaEngine(tank.platform.Engine):
             # after a File->Open receives an up-to-date "previous" context.
             self.__watcher.stop_watching()
             cb_fn = lambda en=self.instance_name, pc=new_context, mn=self._menu_name:on_scene_event_callback(
-                engine_name=en, 
+                engine_name=en,
                 prev_context=pc,
                 menu_name=mn,
             )
@@ -713,11 +713,11 @@ class MayaEngine(tank.platform.Engine):
         #       it to work and instead resorted to the event watcher setup.
 
         # make a unique id for the app widget based off of the panel id
-        widget_id = "wdgt_%s" % panel_id
+        widget_id = "panel_%s" % panel_id
 
         if pm.control(widget_id, query=1, exists=1):
             self.log_debug("Reparent existing toolkit widget %s." % widget_id)
-            # find the widget for later use
+            # Find the Shotgun app panel widget for later use.
             for widget in QtGui.QApplication.allWidgets():
                 if widget.objectName() == widget_id:
                     widget_instance = widget
@@ -726,8 +726,9 @@ class MayaEngine(tank.platform.Engine):
                     self.log_debug("Reparenting widget %s under Maya main window." % widget_id)
                     parent = self._get_dialog_parent()
                     widget_instance.setParent(parent)
+                    # The Shotgun app panel was retrieved from under an existing Maya panel.
+                    new_panel = False
                     break
-
         else:
             self.log_debug("Create toolkit widget %s" % widget_id)
             # parent the UI to the main maya window
@@ -739,9 +740,11 @@ class MayaEngine(tank.platform.Engine):
             self.log_debug("Created widget %s: %s" % (widget_id, widget_instance))
             # apply external stylesheet
             self._apply_external_styleshet(bundle, widget_instance)
+            # The Shotgun app panel was just created.
+            new_panel = True
 
-        # Dock the app panel widget in a new panel tab of Maya Channel Box dock area.
-        maya_panel_name = tk_maya.dock_panel(self, panel_id, widget_instance, title)
+        # Dock the Shotgun app panel into a new Maya panel in the active Maya window.
+        maya_panel_name = tk_maya.dock_panel(self, widget_instance, title, new_panel)
 
         # Add the new panel to the dictionary of Maya panels that have been created by the engine.
         # The panel entry has a Maya panel name key and an app widget instance value.
@@ -750,23 +753,6 @@ class MayaEngine(tank.platform.Engine):
         # close callback is outweighed by the limited length of the dictionary that will never
         # be longer than the number of apps configured to be runnable by the engine.
         self._maya_panel_dict[maya_panel_name] = widget_instance
-
-        # just like nuke, maya doesn't give us any hints when a panel is being closed.
-        # QT widgets contained within this panel are just unparented and the floating
-        # around, taking up memory.
-        #
-        # the visibleChangeCommand callback offered by the dockControl command
-        # doesn't seem to work
-        #
-        # instead, install a QT event watcher to track when the parent
-        # is closed and make sure that the tk widget payload is closed and
-        # deallocated at the same time.
-        #
-        # Also, there are some obscure issues relating to UI refresh. These are also
-        # resolved by looking at the stream of event and force triggering refreshes at the
-        # right locations
-        #
-        tk_maya.install_callbacks(maya_panel_name, widget_id)
 
         return widget_instance
 

--- a/python/tk_maya/__init__.py
+++ b/python/tk_maya/__init__.py
@@ -10,4 +10,3 @@
 
 from .menu_generation import MenuGenerator
 from .panel_generation import dock_panel
-from .panel_util import install_callbacks

--- a/python/tk_maya/panel_generation.py
+++ b/python/tk_maya/panel_generation.py
@@ -161,17 +161,6 @@ def dock_panel(engine, shotgun_panel, title, new_panel):
                     "    maya.utils.executeInMainThreadWithResult(fct, msg)\n" \
                     % {"panel_name": shotgun_panel_name}
 
-        # Give an initial width to the docked Shotgun app panel when first shown.
-        # Otherwise, the workspace control would use the width of the currently displayed tab.
-        size_hint = shotgun_panel.sizeHint()
-        if size_hint.isValid():
-            # Use the widget layout preferred width.
-            widget_width = size_hint.width()
-        else:
-            # Since no size is recommended, use the current width.
-            widget_width = shotgun_panel.width()
-        engine.log_debug("Widget %s size: %s" % (shotgun_panel_name, widget_width))
-
         # Dock the Shotgun app panel into a new workspace control in the active Maya workspace.
         engine.log_debug("Creating Maya workspace panel %s." % maya_panel_name)
 
@@ -179,8 +168,6 @@ def dock_panel(engine, shotgun_panel, title, new_panel):
                   "loadImmediately": True,
                   "retain": False,  # delete the dock tab when it is closed
                   "label": title,
-                  "initialWidth": widget_width,
-                  "minimumWidth": True,  # set the minimum width to the initial width
                   "r": True}  # raise at the top of its workspace area
 
         if current_workspace == "Maya Classic":
@@ -188,12 +175,9 @@ def dock_panel(engine, shotgun_panel, title, new_panel):
             # Dock the Shotgun app panel into a new tab of this Channel Box dock area,
             # since the user was used to this behaviour in previous versions of Maya.
             kwargs["tabToControl"] = (dock_area, -1)  # -1 to append a new tab
-        else:
-            # We are in a new Maya 2017 workspace where the Channel Box dock area might not be found.
-            # Dock the Shotgun app panel into a new Maya panel at the right of Maya main window.
-            # Trying to dock in a missing Channel Box dock area would make Maya embed the Shotgun
-            # app panel into a floating workspace control window reduced to its title bar in size.
-            kwargs["dockToMainWindow"] = ("right", False)
+
+        # When we are in a new Maya 2017 workspace where the Channel Box dock area might not be found,
+        # let Maya embed the Shotgun app panel into a floating workspace control window.
 
         cmds.workspaceControl(maya_panel_name, **kwargs)
 
@@ -233,6 +217,9 @@ def build_workspace_control_ui(shotgun_panel_name):
 
             # Reparent the Shotgun app panel widget under Maya workspace control.
             widget.setParent(workspace_control)
+
+            # Add the Shotgun app panel widget to the Maya workspace control layout.
+            workspace_control.layout().addWidget(widget)
 
             # Install an event filter on Maya workspace control to monitor
             # its close event in order to reparent the Shotgun app panel widget

--- a/python/tk_maya/panel_generation.py
+++ b/python/tk_maya/panel_generation.py
@@ -8,39 +8,47 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-def dock_panel(engine, panel_id, widget_instance, title):
+from . import panel_util
+
+
+def dock_panel(engine, shotgun_panel, title, new_panel):
     """
-    Docks a Shotgun app panel widget in a new panel tab of Maya Channel Box dock area.
+    Docks a Shotgun app panel into a new Maya panel in the active Maya window.
+
+    In Maya 2016 and before, the panel is docked into a new tab of Maya Channel Box dock area.
+    In Maya 2017 and after, the panel is docked into a new workspace area in the active Maya workspace.
 
     :param engine: :class:`MayaEngine` instance running in Maya.
-    :param panel_id: Unique string identifier for the Shotgun app panel.
-    :param widget_instance: Qt widget at the root of the Shotgun app panel.
-                            This Qt widget is assumed to be child of Maya main window.
-                            Its name can be used in standard Maya commands to reparent it under a Maya panel.
+    :param shotgun_panel: Qt widget at the root of the Shotgun app panel.
+                          This Qt widget is assumed to be child of Maya main window.
+                          Its name can be used in standard Maya commands to reparent it under a Maya panel.
     :param title: Title to give to the new dock tab.
-    :returns: Name of the new Maya panel.
+    :param new_panel: True when the Shotgun app panel was just created by the calling function.
+                      False when the Shotgun app panel was retrieved from under an existing Maya panel.
+    :returns: Name of the newly created Maya panel.
     """
 
     # The imports are done here rather than at the module level to avoid spurious imports
     # when this module is reloaded in the context of a workspace control UI script.
     import maya.mel as mel
-    import maya.utils
-    import pymel.core as pm
 
-    # Retrieve the unique string identifier naming the Qt widget.
-    widget_id = widget_instance.objectName()
-
-    # Create the Maya panel name.
-    maya_panel_id = "panel_%s" % panel_id
-
-    # When the Maya panel already exists, it can be deleted safely since its embedded
-    # Shotgun app panel widget has already been reparented under Maya main window.
-    if pm.control(maya_panel_id, query=True, exists=True):
-        engine.log_debug("Deleting existing Maya panel %s." % maya_panel_id)
-        pm.deleteUI(maya_panel_id)
+    # Retrieve the Shotgun app panel name.
+    shotgun_panel_name = shotgun_panel.objectName()
 
     # Use the proper Maya panel docking method according to the Maya version.
     if mel.eval("getApplicationVersionAsFloat()") < 2017:
+
+        import maya.utils
+        import pymel.core as pm
+
+        # Create a Maya panel name.
+        maya_panel_name = "maya_%s" % shotgun_panel_name
+
+        # When the Maya panel already exists, it can be deleted safely since its embedded
+        # Shotgun app panel has already been reparented under Maya main window.
+        if pm.control(maya_panel_name, query=True, exists=True):
+            engine.log_debug("Deleting existing Maya panel %s." % maya_panel_name)
+            pm.deleteUI(maya_panel_name)
 
         # Create a new Maya window.
         maya_window = pm.window()
@@ -50,121 +58,168 @@ def dock_panel(engine, panel_id, widget_instance, title):
         maya_layout = pm.formLayout(parent=maya_window)
         engine.log_debug("Created Maya layout %s." % maya_layout)
 
-        # Reparent the Shotgun app panel widget under the Maya window layout.
-        engine.log_debug("Reparenting Shotgun app panel widget %s under Maya layout %s." % (widget_id, maya_layout))
-        pm.control(widget_id, edit=True, parent=maya_layout)
+        # Reparent the Shotgun app panel under the Maya window layout.
+        engine.log_debug("Reparenting Shotgun app panel %s under Maya layout %s." % (shotgun_panel_name, maya_layout))
+        pm.control(shotgun_panel_name, edit=True, parent=maya_layout)
 
-        # Keep the Shotgun app panel widget sides aligned with the Maya window layout sides.
+        # Keep the Shotgun app panel sides aligned with the Maya window layout sides.
         pm.formLayout(maya_layout,
                       edit=True,
-                      attachForm=[(widget_id, 'top', 1),
-                                  (widget_id, 'left', 1),
-                                  (widget_id, 'bottom', 1),
-                                  (widget_id, 'right', 1)]
+                      attachForm=[(shotgun_panel_name, 'top', 1),
+                                  (shotgun_panel_name, 'left', 1),
+                                  (shotgun_panel_name, 'bottom', 1),
+                                  (shotgun_panel_name, 'right', 1)]
         )
 
         # Dock the Maya window into a new tab of Maya Channel Box dock area.
-        engine.log_debug("Creating Maya panel %s." % maya_panel_id)
-        pm.dockControl(maya_panel_id, area="right", content=maya_window, label=title)
+        engine.log_debug("Creating Maya panel %s." % maya_panel_name)
+        pm.dockControl(maya_panel_name, area="right", content=maya_window, label=title)
+
+        # Since Maya does not give us any hints when a panel is being closed,
+        # install an event filter on Maya dock control to monitor its close event
+        # in order to gracefully close and delete the Shotgun app panel widget.
+        # Some obscure issues relating to UI refresh are also resolved by the event filter.
+        panel_util.install_event_filter_by_name(maya_panel_name, shotgun_panel_name)
 
         # Once Maya will have completed its UI update and be idle,
         # raise (with "r=True") the new dock tab to the top.
-        maya.utils.executeDeferred("cmds.dockControl('%s', edit=True, r=True)" % maya_panel_id)
+        maya.utils.executeDeferred("import maya.cmds as cmds\n" \
+                                   "cmds.dockControl('%s', edit=True, r=True)" % maya_panel_name)
 
     else:  # Maya 2017 and later
 
-        # Delete any default workspace control state that might have been automatically
-        # created by Maya when a previously existing Maya panel was closed and deleted.
-        if pm.workspaceControlState(maya_panel_id, exists=True):
-            engine.log_debug("Deleting existing Maya workspace panel state %s." % maya_panel_id)
-            pm.workspaceControlState(maya_panel_id, remove=True)
+        import maya.cmds as cmds
+
+        # Create a Maya panel name in the current Maya workspace.
+        # We need to use different names for different workspaces in order for
+        # each workspace control location to be saved and restored properly
+        # when the user swithces from one workspace to another.
+        current_workspace = cmds.workspaceLayoutManager(query=True, current=True)
+        maya_panel_name = "maya_%s_%s" % (current_workspace, shotgun_panel_name)
+        # Make sure the name is a valid Maya object name.
+        maya_panel_name = mel.eval('formValidObjectName("%s")' % maya_panel_name)
+
+        # When the Maya panel already exists, it can be deleted safely since its embedded
+        # Shotgun app panel has already been reparented under Maya main window.
+        if cmds.workspaceControl(maya_panel_name, query=True, exists=True):
+            engine.log_debug("Deleting existing Maya panel %s." % maya_panel_name)
+            cmds.deleteUI(maya_panel_name)
+
+        if cmds.workspaceControlState(maya_panel_name, exists=True):
+            # We have a saved workspace control state created by Maya from a workspace control that was
+            # previously closed and deleted when the user swithced to another workspace or exited Maya.
+            if new_panel:
+                # When the Shotgun app panel was just created by the calling function, let Maya
+                # embed it into a workspace control restored from the workspace control state.
+                # This case happens when the engine has just been started and the Shotgun app panel
+                # is displayed for the first time around.
+                # In Maya 2017, switching to another workspace then back is the only straightforward
+                # way to make Maya automatically recreate the workspace control and call its UI script.
+                engine.log_debug("Making Maya recreate workspace panel %s." % maya_panel_name)
+                cmds.workspaceLayoutManager(saveAs="Shotgun")
+                cmds.workspaceLayoutManager(setCurrent=current_workspace)
+                cmds.workspaceLayoutManager(delete="Shotgun")
+                return maya_panel_name
+            else:
+                # When the Shotgun app panel was retrieved from under an existing Maya panel,
+                # delete the workspace control state since we want to recreate our default workspace control.
+                engine.log_debug("Deleting existing Maya workspace panel state %s." % maya_panel_name)
+                cmds.workspaceControlState(maya_panel_name, remove=True)
 
         # Retrieve the Channel Box dock area, with error reporting turned off.
         # This MEL function is declared in Maya startup script file UIComponents.mel.
-        # It returns an empty string when this dock area cannot be found in the active Maya workspace.
+        # It returns an empty string when a dock area cannot be found, but Maya will
+        # retrieve the Channel Box dock area even when it is not shown in the current workspace.
         dock_area = mel.eval('getUIComponentDockControl("Channel Box / Layer Editor", false)')
         engine.log_debug("Retrieved Maya dock area %s." % dock_area)
 
         # This UI script will be called to build the UI of the new dock tab.
-        # It will embed the Shotgun app panel widget into a Maya workspace control.
-        # Maya 2017 expects this script to be passed in as a string, not as a function pointer.
-        # See function _build_workspace_control_ui() below for a commented version of this script.
-        ui_script = "import pymel.core as pm\n" \
-                    "workspace_control = pm.setParent(query=True)\n" \
-                    "pm.control('%s', edit=True, parent=workspace_control)" \
-                    % widget_id
+        # It will embed the Shotgun app panel into a Maya workspace control.
+        # Since Maya 2017 expects this script to be passed in as a string,
+        # not as a function pointer, it must retrieve the current module in order
+        # to call function build_workspace_control_ui() that actually builds the UI.
+        # Note that this script will be saved automatically with the workspace control state
+        # in the Maya layout preference file when the user quits Maya, and will be executed
+        # automatically when Maya is restarted later by the user.
+        ui_script = "import sys\n" \
+                    "for m in sys.modules:\n" \
+                    "    if 'tk_maya.panel_generation' in m:\n" \
+                    "        sys.modules[m].build_workspace_control_ui('%s')\n" \
+                    "        break" \
+                    % shotgun_panel_name
 
-        # The following UI script can be used for development and debugging purposes.
-        # This script has to retrieve and import the current source file in order to call
-        # function _build_workspace_control_ui() below to build the workspace control UI.
-        # ui_script = "import imp\n" \
-        #             "panel_generation = imp.load_source('%s', '%s')\n" \
-        #             "panel_generation._build_workspace_control_ui('%s')" \
-        #             % (__name__, __file__.replace(".pyc", ".py"), widget_id)
-
-        # Give an initial width to the docked Shotgun app panel widget when first shown.
+        # Give an initial width to the docked Shotgun app panel when first shown.
         # Otherwise, the workspace control would use the width of the currently displayed tab.
-        size_hint = widget_instance.sizeHint()
+        size_hint = shotgun_panel.sizeHint()
         if size_hint.isValid():
-            # Use the widget layout preferred size.
+            # Use the widget layout preferred width.
             widget_width = size_hint.width()
         else:
-            # Since no size is recommended for the widget, use its current width.
-            widget_width = widget_instance.width()
-        engine.log_debug("Widget %s width: %s" % (widget_id, widget_width))
+            # Since no size is recommended, use the current width.
+            widget_width = shotgun_panel.width()
+        engine.log_debug("Widget %s size: %s" % (shotgun_panel_name, widget_width))
 
-        # Dock the Shotgun app panel widget into a new tab of the Channel Box dock area.
-        # When this dock area was not found in the active Maya workspace,
-        # the Shotgun app panel widget is embedded into a floating workspace control window.
-        # This floating workspace control can then be docked into an existing dock area by the user.
-        engine.log_debug("Creating Maya workspace panel %s." % maya_panel_id)
-        dock_tab = pm.workspaceControl(maya_panel_id,
-                                       tabToControl=(dock_area, -1),  # -1 to append a new tab
-                                       uiScript=ui_script,
-                                       loadImmediately=True,
-                                       retain=False,  # delete the dock tab when it is closed
-                                       label=title,
-                                       initialWidth=widget_width,
-                                       minimumWidth=True,  # set the minimum width to the initial width
-                                       r=True  # raise the new dock tab to the top
-                   )
+        # Dock the Shotgun app panel into a new workspace control in the active Maya workspace.
+        engine.log_debug("Creating Maya workspace panel %s." % maya_panel_name)
 
-        # Now that the workspace dock tab has been created, let's update its UI script.
-        # This updated script will be saved automatically with the workspace control state
-        # in the Maya layout preference file when the user will choose to quit Maya,
-        # and will be executed automatically when Maya is restarted later by the user.
+        kwargs = {"uiScript": ui_script,
+                  "loadImmediately": True,
+                  "retain": False,  # delete the dock tab when it is closed
+                  "label": title,
+                  "initialWidth": widget_width,
+                  "minimumWidth": True,  # set the minimum width to the initial width
+                  "r": True}  # raise at the top of its workspace area
 
-        # The script will delete the empty workspace dock tab that Maya will recreate on startup
-        # when the user previously chose to quit Maya while the panel was opened.
-        deferred_script = "import maya.cmds as cmds\\n" \
-                          "if cmds.workspaceControl('%(id)s', exists=True):\\n" \
-                          "    cmds.deleteUI('%(id)s')" \
-                          % {"id": maya_panel_id}
+        if current_workspace == "Maya Classic":
+            # We are in the default Maya workspace where the Channel Box dock area can be found.
+            # Dock the Shotgun app panel into a new tab of this Channel Box dock area,
+            # since the user was used to this behaviour in previous versions of Maya.
+            kwargs["tabToControl"] = (dock_area, -1)  # -1 to append a new tab
+        else:
+            # We are in a new Maya 2017 workspace where the Channel Box dock area might not be found.
+            # Dock the Shotgun app panel into a new Maya panel at the right of Maya main window.
+            # Trying to dock in a missing Channel Box dock area would make Maya embed the Shotgun
+            # app panel into a floating workspace control window reduced to its title bar in size.
+            kwargs["dockToMainWindow"] = ("right", False)
 
-        # The previous script will need to be executed once Maya has completed its UI update and be idle.
-        ui_script = "import maya.utils\n" \
-                    "maya.utils.executeDeferred(\"%s\")\n" \
-                    % deferred_script
+        cmds.workspaceControl(maya_panel_name, **kwargs)
 
-        # Update the workspace dock tab UI script.
-        pm.workspaceControl(maya_panel_id, edit=True, uiScript=ui_script)
-
-    return maya_panel_id
+    return maya_panel_name
 
 
-def _build_workspace_control_ui(widget_id):
+def build_workspace_control_ui(shotgun_panel_name):
     """
-    Embed a Shotgun app panel widget into the calling Maya workspace control.
+    Embeds a Shotgun app panel into the calling Maya workspace control.
 
-    :param widget_id: Unique string identifier naming the Qt widget at the root of the Shotgun app panel.
-                      This Qt widget is assumed to be child of Maya main window.
-                      Its name can be used in standard Maya commands to reparent it under a Maya panel.
+    This function will be called in two cases:
+    - When the workspace control is being created by Maya command workspaceControl;
+    - When the workspace control is being restored from a workspace control state
+      created by Maya when this workspace control was previously closed and deleted.
+
+    :param shotgun_panel_name: Name of the Qt widget at the root of a Shotgun app panel.
     """
 
-    import pymel.core as pm
+    from maya.OpenMayaUI import MQtUtil
 
-    # In the context of this function, setParent() returns the calling workspace control.
-    workspace_control = pm.setParent(query=True)
+    # In the context of this function, we know that we are running in Maya 2017 and later
+    # with the newer versions of PySide and shiboken.
+    from PySide2 import QtWidgets
+    from shiboken2 import wrapInstance
 
-    # Reparent the Shotgun app panel widget under the workspace control.
-    pm.control(widget_id, edit=True, parent=workspace_control)
+    # Retrieve the calling Maya workspace control.
+    ptr = MQtUtil.getCurrentParent()
+    workspace_control = wrapInstance(long(ptr), QtWidgets.QWidget)
+
+    # Search for the Shotgun app panel widget.
+    for widget in QtWidgets.QApplication.allWidgets():
+        if widget.objectName() == shotgun_panel_name:
+
+            # Reparent the Shotgun app panel widget under Maya workspace control.
+            widget.setParent(workspace_control)
+
+            # Install an event filter on Maya workspace control to monitor
+            # its close event in order to reparent the Shotgun app panel widget
+            # under Maya main window for later use.
+            panel_util.install_event_filter_by_widget(workspace_control, shotgun_panel_name)
+
+            break


### PR DESCRIPTION
The opened Shotgun app panels docked in a Maya 2017 workspace are restored to their saved locations:
- when the user switches back to this workspace after displaying another workspace,
- when the user restarts Maya and the tk-maya engine is rebooted.

When switching from one workspace to another, the opened Shotgun app panels retain their current UI states.
