### PR TITLE
For #39543, Load toolkit plugins on Maya launch

### DIFF
--- a/info.yml
+++ b/info.yml
@@ -74,6 +74,11 @@ configuration:
         description: Optionally choose to use 'Sgtk' as the primary menu name instead of 'Shotgun'
         default_value: false
 
+    launch_builtin_plugin:
+        type: str
+        description: Comma-separated list of tk-maya plugins to load when launching Maya
+        default_value: ""
+
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:
         

--- a/info.yml
+++ b/info.yml
@@ -76,7 +76,11 @@ configuration:
 
     launch_builtin_plugin:
         type: str
-        description: Comma-separated list of tk-maya plugins to load when launching Maya
+        description: Comma-separated list of tk-maya plugins to load when launching Maya. Use
+                     of this feature disables the classic mechanism for bootstrapping Toolkit
+                     when Maya is launched. Therefore, if any plugins are specified using this
+                     setting, the first one in the list must be responsible for starting Toolkit
+                     when Maya is launched.
         default_value: ""
 
 # the Shotgun fields that this engine needs in order to operate correctly

--- a/startup.py
+++ b/startup.py
@@ -97,7 +97,7 @@ class MayaLauncher(SoftwareLauncher):
             (entity_type, entity_id) = _context_entity_type_id(self.context)
             required_env["SHOTGUN_SITE"] = self.sgtk.shotgun_url
             required_env["SHOTGUN_ENTITY_TYPE"] = entity_type
-            required_env["SHOTGUN_ENTITY_ID"] = entity_id
+            required_env["SHOTGUN_ENTITY_ID"] = str(entity_id)
         else:
             self.logger.info("Preparing Maya Launch via Toolkit Classic methodology ...")
             required_env["SGTK_ENGINE"] = self.engine_name

--- a/startup.py
+++ b/startup.py
@@ -10,6 +10,7 @@
 
 import os
 import sys
+import re
 import glob
 import subprocess
 import xml.etree.ElementTree as XML_ET
@@ -46,7 +47,7 @@ class MayaLauncher(SoftwareLauncher):
             # Look for executables in paths formerly specified by the
             # default configuration paths.yml file.
             sw_versions = _default_path_software_versions(
-                self._logger, versions, display_name, icon
+                self.logger, versions, display_name, icon
             )
         if not sw_versions:
             self.logger.info(
@@ -156,7 +157,6 @@ def _synergy_config_files():
 
     return synergy_configs
 
-
 def _synergy_software_versions(logger, versions=None, display_name=None, icon=None):
     """
     Creates SoftwareVersion instances based on the Synergy configuration
@@ -214,7 +214,7 @@ def _synergy_software_versions(logger, versions=None, display_name=None, icon=No
 
         if versions and synergy_data["NumericVersion"] not in versions:
             # If this version isn't in the list of requested versions, skip it.
-            logger.debug("Skipping Maya version %s ..." % synergy_data["NumericVersion"])
+            logger.debug("Skipping Maya Synergy version %s ..." % synergy_data["NumericVersion"])
             continue
 
         exec_path = synergy_data["ExecutablePath"]
@@ -314,6 +314,11 @@ def _default_path_software_versions(logger, versions=None, display_name=None, ic
                 # Parse the default version from the display name determined from
                 # the version output.
                 default_version = default_display.lower().replace("maya", "").strip()
+
+            if versions and default_version not in versions:
+                # If this version isn't in the list of requested versions, skip it.
+                logger.debug("Skipping Maya default version %s ..." % default_version)
+                continue
 
             if sys.platform == "darwin" and "Maya.app" in exec_path:
                 # There seems to be an anomoly with launching Maya from the

--- a/startup.py
+++ b/startup.py
@@ -1,0 +1,150 @@
+# Copyright (c) 2016 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+import os
+import sys
+import sgtk
+import xml.etree.ElementTree as XET
+
+from sgtk.platform import SoftwareLauncher, SoftwareVersion, LaunchInformation
+
+class MayaLauncher(SoftwareLauncher):
+    """
+    Handles launching Maya in an engine-agnostic manner.
+    """
+
+    def synergy_paths(self):
+        """
+        Override base class definition to restrict list of Synergy
+        Config files to be Maya-specific
+        """
+        if self._synergy_paths is None:
+            # Let the parent class deal with finding the files
+            all_paths = SoftwareLauncher.synergy_paths(self)
+            # Now pick out the specific ones for Maya.
+            self._synergy_paths = [
+                p for p in all_paths if os.path.basename(p).startswith("Maya")
+            ]
+        return self._synergy_paths
+
+    def scan_software(self, versions=None):
+        """
+        Performs a scan for software installations.
+
+        :param versions: List of strings representing versions
+                         to search for. If set to None, search
+                         for all versions. A version string is
+                         DCC-specific but could be something
+                         like "2017", "6.3v7" or "1.2.3.52"
+        :returns: List of :class:`SoftwareVersion` instances
+        """
+        sw_versions = []
+        for synergy_cfg in self.synergy_paths():
+            swv = self._software_version_from_synergy(synergy_cfg)
+            if not swv:
+                self.logger.debug(
+                    "Could not create SoftwareVersion from Synergy config '%s'" %
+                    (synergy_cfg)
+                )
+                continue
+            if versions and isinstance(versions, list) and str(swv.version) not in versions:
+                self.logger.debug(
+                    "Resolved version for Synergy config '%s' [%s] not found "
+                    "in specified list of versions : %s" %
+                    (synergy_cfg, swv.version, versions)
+                )
+                continue
+            sw_versions.append(swv)
+
+        [self._customize_software_version(swv) for swv in sw_versions]
+
+        return sw_versions
+
+    def resolve_software(self, sw_path):
+        """
+        Resolve a software instance for a given DCC path
+
+        :param path:
+        :returns: SoftwareVersion instance
+        """
+        synergy_data = self._synergy_data_from_executable(sw_path)
+        if not synergy_data:
+            return None
+
+        sw_version = self._sofware_version_from_synergy(syn_data=synergy_data)
+        return self._customize_software_version(sw_version)
+
+    def prepare_launch(self, software_version, args, options, file_to_open=None):
+        """
+        Prepares the given software for launch
+
+        :param software_version: Software Version to launch
+        :param args: Command line arguments as strings
+        :param options: DCC specific options to pass
+        :param file_to_open: (Optional) Full path name of a file to open on launch
+        :returns: LaunchInformation instance
+        """
+        clean_env = os.environ.copy()
+        startup_path = os.path.join(self.disk_location, "startup")
+        sgtk.util.append_path_to_env_var("PYTHONPATH", startup_path)
+        os.environ["TANK_ENGINE"] = self.engine_name
+        os.environ["TANK_CONTEXT"] = sgtk.context.serialize(self.context)
+        if file_to_open:
+            os.environ["TANK_FILE_TO_OPEN"] = file_to_open
+
+        launch_info = LaunchInformation(
+            software_version.path, args, os.environ.copy(),
+        )
+        os.environ.clear()
+        os.environ.update(clean_env)
+
+        return launch_info
+
+    def _icon_from_executable(self, exec_path):
+        """
+        Find the application icon based on the executable path and
+        current platform.
+
+        :param exec_path: Full path to the executable
+        :returns: Full path to application icon as a string or None.
+        """
+        icon_base_path = ""
+        if sys.platform == "darwin" and "Maya.app" in exec_path:
+            icon_base_path = os.path.join(
+                "".join(exec_path.partition("Maya.app")[0:2]),
+                "Contents"
+            )
+
+        elif sys.platform in ["win32", "linux2"] and "bin" in exec_path:
+            icon_base_path = "".join(exec_path.partition("bin")[0:1])
+
+        icon_path = os.path.join(icon_base_path, "icons", "mayaico.png")
+        return icon_path if os.path.exists(icon_path) else None
+
+    def _customize_software_version(self, sw_version):
+        """
+        Update SoftwareVersions retrieved from the parent class
+        with Maya specific information.
+
+        :param sw_version: SoftwareVersion instance to be updated.
+        """
+        if not sw_version:
+            # There's nothing to do
+            return sw_version
+
+        # Set the default icon
+        sw_version.icon = self._icon_from_executable(sw_version.path)
+
+        if sys.platform  == "darwin" and "Maya.app" in sw_version.path:
+            # There seems to be an anomoly with launching Maya from the
+            # full executable path on MacOS. Everything behaves nicer if
+            # Maya is launched from the bundle Maya.app directory instead.
+            sw_version.path = "".join(sw_version.path.partition("Maya.app")[0:2])
+

--- a/startup.py
+++ b/startup.py
@@ -10,31 +10,19 @@
 
 import os
 import sys
-import sgtk
-import xml.etree.ElementTree as XET
+import glob
+import subprocess
+import xml.etree.ElementTree as XML_ET
 
+import sgtk
+from sgtk import TankError
 from sgtk.platform import SoftwareLauncher, SoftwareVersion, LaunchInformation
 
 class MayaLauncher(SoftwareLauncher):
     """
-    Handles launching Maya in an engine-agnostic manner.
+    Handles launching Maya without having an active engine.
     """
-
-    def synergy_paths(self):
-        """
-        Override base class definition to restrict list of Synergy
-        Config files to be Maya-specific
-        """
-        if self._synergy_paths is None:
-            # Let the parent class deal with finding the files
-            all_paths = SoftwareLauncher.synergy_paths(self)
-            # Now pick out the specific ones for Maya.
-            self._synergy_paths = [
-                p for p in all_paths if os.path.basename(p).startswith("Maya")
-            ]
-        return self._synergy_paths
-
-    def scan_software(self, versions=None):
+    def scan_software(self, versions=None, display_name=None, icon=None):
         """
         Performs a scan for software installations.
 
@@ -43,108 +31,305 @@ class MayaLauncher(SoftwareLauncher):
                          for all versions. A version string is
                          DCC-specific but could be something
                          like "2017", "6.3v7" or "1.2.3.52"
+        :param display_name: (optional) Specify label to use for all
+                             SoftwareVersions found.
+        :param icon: (optional) Specify icon to use for all
+                     SoftwareVersions found.
+
         :returns: List of :class:`SoftwareVersion` instances
         """
-        sw_versions = []
-        for synergy_cfg in self.synergy_paths():
-            swv = self._software_version_from_synergy(synergy_cfg)
-            if not swv:
-                self.logger.debug(
-                    "Could not create SoftwareVersion from Synergy config '%s'" %
-                    (synergy_cfg)
-                )
-                continue
-            if versions and isinstance(versions, list) and str(swv.version) not in versions:
-                self.logger.debug(
-                    "Resolved version for Synergy config '%s' [%s] not found "
-                    "in specified list of versions : %s" %
-                    (synergy_cfg, swv.version, versions)
-                )
-                continue
-            sw_versions.append(swv)
+        # First look for executables using the Autodesk Synergy registry.
+        sw_versions = _synergy_software_versions(
+            self.logger, versions, display_name, icon
+        )
+        if not sw_versions:
+            # Look for executables in paths formerly specified by the
+            # default configuration paths.yml file.
+            sw_versions = _default_path_software_versions(
+                self._logger, versions, display_name, icon
+            )
+        if not sw_versions:
+            self.logger.info(
+                "Unable to determine available SoftwareVersions for engine %s" %
+                self.engine_name
+            )
+            return []
 
-        [self._customize_software_version(swv) for swv in sw_versions]
+        return  sw_versions
 
-        return sw_versions
 
-    def resolve_software(self, sw_path):
-        """
-        Resolve a software instance for a given DCC path
-
-        :param path:
-        :returns: SoftwareVersion instance
-        """
-        synergy_data = self._synergy_data_from_executable(sw_path)
-        if not synergy_data:
-            return None
-
-        sw_version = self._sofware_version_from_synergy(syn_data=synergy_data)
-        return self._customize_software_version(sw_version)
-
-    def prepare_launch(self, software_version, args, options, file_to_open=None):
+    def prepare_launch(self, exec_path, args, options, file_to_open=None):
         """
         Prepares the given software for launch
 
-        :param software_version: Software Version to launch
+        :param exec_path: Path to DCC executable to launch
         :param args: Command line arguments as strings
         :param options: DCC specific options to pass
         :param file_to_open: (Optional) Full path name of a file to open on launch
+
         :returns: LaunchInformation instance
         """
-        clean_env = os.environ.copy()
+        required_env = {}
         startup_path = os.path.join(self.disk_location, "startup")
         sgtk.util.append_path_to_env_var("PYTHONPATH", startup_path)
-        os.environ["TANK_ENGINE"] = self.engine_name
-        os.environ["TANK_CONTEXT"] = sgtk.context.serialize(self.context)
+        required_env["PYTHONPATH"] = os.environ["PYTHONPATH"]
+        required_env["TANK_ENGINE"] = self.engine_name
+        required_env["TANK_CONTEXT"] = sgtk.context.serialize(self.context)
         if file_to_open:
-            os.environ["TANK_FILE_TO_OPEN"] = file_to_open
+            required_env["TANK_FILE_TO_OPEN"] = file_to_open
 
-        launch_info = LaunchInformation(
-            software_version.path, args, os.environ.copy(),
+        return LaunchInformation(exec_path, args, required_env)
+
+
+def _icon_from_executable(exec_path):
+    """
+    Find the application icon based on the executable path and
+    current platform.
+
+    :param exec_path: Full path to the executable
+
+    :returns: Full path to application icon as a string or None.
+    """
+    icon_base_path = ""
+    if sys.platform == "darwin" and "Maya.app" in exec_path:
+        # e.g. /Applications/Autodesk/maya2016.5/Maya.app/Contents
+        icon_base_path = os.path.join(
+            "".join(exec_path.partition("Maya.app")[0:2]),
+            "Contents"
         )
-        os.environ.clear()
-        os.environ.update(clean_env)
 
-        return launch_info
+    elif sys.platform in ["win32", "linux2"] and "bin" in exec_path:
+        # e.g. C:\Program Files\Autodesk\Maya2017\  or
+        #      /usr/autodesk/maya2017/
+        icon_base_path = "".join(exec_path.partition("bin")[0:1])
 
-    def _icon_from_executable(self, exec_path):
-        """
-        Find the application icon based on the executable path and
-        current platform.
+    if not icon_base_path:
+        # If no base path, no icon
+        return None
 
-        :param exec_path: Full path to the executable
-        :returns: Full path to application icon as a string or None.
-        """
-        icon_base_path = ""
-        if sys.platform == "darwin" and "Maya.app" in exec_path:
-            icon_base_path = os.path.join(
-                "".join(exec_path.partition("Maya.app")[0:2]),
-                "Contents"
+    # Append the standard icon to the base path and
+    # return that path if it exists, else None.
+    icon_path = os.path.join(icon_base_path, "icons", "mayaico.png")
+    return icon_path if os.path.exists(icon_path) else None
+
+
+def _synergy_config_files():
+    """
+    Scans the local file system using a list of search paths for
+    Autodesk Synergy Config files (.syncfg).
+
+    :returns: List of path names to Synergy Config files found
+              in the local environment
+    """
+    # Check for custom paths defined by the SYNHUB_CONFIG_PATH env var.
+    env_paths = os.environ.get("SYNHUB_CONFIG_PATH")
+    search_paths = []
+    if isinstance(env_paths, basestring):
+        # This can be a list of directories and/or files.
+        search_paths = env_paths.split(os.pathsep)
+
+    # Check the platfom-specific default installation path
+    # if no paths were set in the environment
+    elif sys.platform == "darwin":
+        search_paths = ["/Applications/Autodesk/Synergy/"]
+    elif sys.platform == "win32":
+        search_paths = ["C:\\ProgramData\\Autodesk\\Synergy\\"]
+    elif sys.platform == "linux2":
+        search_paths = ["/opt/Autodesk/Synergy/"]
+    else:
+        return search_paths
+
+    synergy_configs = []
+    for search_path in search_paths:
+        if os.path.isdir(search_path):
+            # Get the list of *.syncfg files in this directory
+            synergy_configs.extend([
+                os.path.join(search_path, f) for f in os.listdir(search_path)
+                if f.startswith("Maya") and f.endswith(".syncfg")
+            ])
+
+        elif os.path.isfile(search_path):
+            file_name = os.path.basename(search_path)
+            if file_name.find("Maya") > -1 and file_name.endswith(".syncfg"):
+                # Add the specified Synergy Config file directly to the list of paths.
+                synergy_configs.append(search_path)
+
+    return synergy_configs
+
+
+def _synergy_software_versions(logger, versions=None, display_name=None, icon=None):
+    """
+    Creates SoftwareVersion instances based on the Synergy configuration
+    data from Synergy Config (.syncfg) files found in the local environment.
+
+    :param logger: Logger instance to use to log messages.
+    :param versions: (optional) Specific list of version numbers (as strings) to
+                     find matching executables for.
+    :param display_name: (optional) Specify label to use for all
+                         SoftwareVersions found.
+    :param icon: (optional) Specify icon to use for all
+                 SoftwareVersions found.
+
+    :returns: List of :class:`SoftwareVersion` SoftwareVersion instance.
+    """
+    # Get the list of Maya*.syncfg files in the local environment
+    configs = _synergy_config_files()
+    if not configs:
+        logger.debug(
+            "Unable to determine Autodesk Synergy paths for platform "%
+            sys.platform
+        )
+        return []
+
+    logger.debug("Found Autodesk Synergy Maya config files : %s" % configs)
+    # Determine the list of SoftwareVersion to return from the list
+    # of configurations found and the list of versions requested.
+    sw_versions = []
+    for config in configs:
+        try:
+            # Parse the Synergy Config file as XML
+            doc = XML_ET.parse(config)
+        except Exception, e:
+            raise TankError(
+                "Caught exception attempting to parse [%s] as XML.\n%s" % (config, e)
             )
 
-        elif sys.platform in ["win32", "linux2"] and "bin" in exec_path:
-            icon_base_path = "".join(exec_path.partition("bin")[0:1])
+        try:
+            # Find the <Application> element that contains the data
+            # we want.
+            app_elem = doc.getroot().find("Application")
+            if app_elem is None:
+                logger.warning(
+                    "No <Application> found in Synergy config file '%s'." % config
+                )
+                continue
 
-        icon_path = os.path.join(icon_base_path, "icons", "mayaico.png")
-        return icon_path if os.path.exists(icon_path) else None
+            # Convert the element's attribute/value pairs to a dictionary
+            synergy_data = dict(app_elem.items())
+        except Exception, e:
+            raise TankError(
+                "Caught unknown exception retrieving <Application> data from %s:\n%s" %
+                (config, e)
+            )
 
-    def _customize_software_version(self, sw_version):
-        """
-        Update SoftwareVersions retrieved from the parent class
-        with Maya specific information.
+        if versions and synergy_data["NumericVersion"] not in versions:
+            # If this version isn't in the list of requested versions, skip it.
+            logger.debug("Skipping Maya version %s ..." % synergy_data["NumericVersion"])
+            continue
 
-        :param sw_version: SoftwareVersion instance to be updated.
-        """
-        if not sw_version:
-            # There's nothing to do
-            return sw_version
-
-        # Set the default icon
-        sw_version.icon = self._icon_from_executable(sw_version.path)
-
-        if sys.platform  == "darwin" and "Maya.app" in sw_version.path:
+        exec_path = synergy_data["ExecutablePath"]
+        if sys.platform == "darwin" and "Maya.app" in exec_path:
             # There seems to be an anomoly with launching Maya from the
             # full executable path on MacOS. Everything behaves nicer if
             # Maya is launched from the bundle Maya.app directory instead.
-            sw_version.path = "".join(sw_version.path.partition("Maya.app")[0:2])
+            exec_path = "".join(exec_path.partition("Maya.app")[0:2])
 
+        # Create a SoftwareVersion from input and config data.
+        logger.debug("Creating SoftwareVersion for '%s'" % exec_path)
+        sw_versions.append(SoftwareVersion(
+            synergy_data["Name"],
+            synergy_data["NumericVersion"],
+            (display_name or synergy_data["StringVersion"]),
+            exec_path,
+            (icon or _icon_from_executable(exec_path))
+        ))
+
+    return sw_versions
+
+
+def _default_path_software_versions(logger, versions=None, display_name=None, icon=None):
+    """
+    Creates SoftwareVersion instances based on the path values used
+    in the default configuration paths.yml environment.
+
+    :param logger: Logger instance to use to log messages.
+    :param versions: (optional) Specific list of version numbers (as strings) to
+                     find matching executables for.
+    :param display_name: (optional) Specify label to use for all
+                         SoftwareVersions found.
+    :param icon: (optional) Specify icon to use for all
+                 SoftwareVersions found.
+
+    :returns: List of :class:`SoftwareVersion` SoftwareVersion instance.
+    """
+    # Determine a list of paths to search for Maya executables based
+    # on default installation path(s) for the current platform
+    search_paths = []
+    exec_paths = []
+    if sys.platform == "darwin":
+        search_paths = glob.glob("/Applications/Autodesk/maya*")
+
+    elif sys.platform == "win32":
+        search_paths = glob.glob("C:\Program Files\Autodesk\Maya*")
+
+    elif sys.platform == "linux2":
+        exec_paths.append("maya")
+
+    if search_paths:
+        for search_path in search_paths:
+            # Construct the expected executable name for this path.
+            # If it exists, add it to the list of exec_paths to check.
+            exec_path = None
+            if sys.platform == "darwin":
+                exec_path = os.path.join(search_path, "Maya.app", "Contents", "bin", "maya")
+
+            elif sys.platform == "win32":
+                exec_path = os.path.join(search_path, "bin", "maya.exe")
+
+            if exec_path and os.path.exists(exec_path):
+                exec_paths.append(exec_path)
+
+    sw_versions = []
+    sw_version_regex = "%smaya[0-9]+[.0-9]*%s" % (os.path.sep, os.path.sep)
+    if exec_paths:
+        for exec_path in exec_paths:
+            # Check to see if the version number can be parsed from the path name.
+            sw_version_search = re.search(sw_version_regex, exec_path.lower())
+            if sw_version_search is not None:
+                # Use this sub dir to determine the default display name
+                # and version for the SoftwareVersion to be created.
+                default_display = sw_version_search.group(0)[1:-1]
+                default_version = default_display.replace("maya", "")
+                default_display = "Maya %s" % default_version
+            else:
+                try:
+                    # This works, but makes the Desktop project window disappear
+                    # for some reason, which isn't very nice. Therefore, use as a
+                    # last resort.
+                    version_output = subprocess.check_output([exec_path, "-v"])
+                except OSError:
+                    logger.exception(
+                        "Could not retrieve version information from default "
+                        "executable path '%s'." % exec_path
+                    )
+                    continue
+
+                # Display and version information are contained before the first ','
+                # in the output version string.
+                default_display = version_output[0:version_output.find(",")]
+                if "2016 Extension 2 SP1" in default_display:
+                    # Update the display value to know "nicer" version numbers.
+                    default_display = default_display.replace("2016 Extension 2 SP1", "2016.5")
+
+                # Parse the default version from the display name determined from
+                # the version output.
+                default_version = default_display.lower().replace("maya", "").strip()
+
+            if sys.platform == "darwin" and "Maya.app" in exec_path:
+                # There seems to be an anomoly with launching Maya from the
+                # full executable path on MacOS. Everything behaves nicer if
+                # Maya is launched from the bundle Maya.app directory instead.
+                exec_path = "".join(exec_path.partition("Maya.app")[0:2])
+
+            # Create a SoftwareVersion using the information from executable path(s) found
+            # in default locations.
+            logger.debug("Creating SoftwareVersion for executable '%s'." % exec_path)
+            sw_versions.append(SoftwareVersion(
+                default_display.replace(" ", "_"),
+                default_version,
+                (display_name or default_display),
+                exec_path,
+                (icon or _icon_from_executable(exec_path))
+            ))
+
+    return sw_versions

--- a/startup/userSetup.py
+++ b/startup/userSetup.py
@@ -1,0 +1,58 @@
+# Copyright (c) 2013 Shotgun Software Inc.
+# 
+# CONFIDENTIAL AND PROPRIETARY
+# 
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit 
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your 
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights 
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+"""
+This file is loaded automatically by Maya at startup
+It sets up the tank context and prepares the Tank Maya engine.
+"""
+
+
+import os
+import maya.OpenMaya as OpenMaya
+import maya.cmds as cmds
+
+def bootstrap_tank():
+    
+    try:
+        import tank
+    except Exception, e:
+        OpenMaya.MGlobal.displayError("Shotgun: Could not import sgtk! Disabling for now: %s" % e)
+        return
+    
+    if not "TANK_ENGINE" in os.environ:
+        OpenMaya.MGlobal.displayError("Shotgun: Missing required environment variable TANK_ENGINE.")
+        return
+    
+    engine_name = os.environ.get("TANK_ENGINE") 
+    try:
+        context = tank.context.deserialize(os.environ.get("TANK_CONTEXT"))
+    except Exception, e:
+        OpenMaya.MGlobal.displayError("Shotgun: Could not create context! Shotgun Pipeline Toolkit will be disabled. Details: %s" % e)
+        return
+        
+    try:    
+        engine = tank.platform.start_engine(engine_name, context.tank, context)
+    except Exception, e:
+        OpenMaya.MGlobal.displayError("Shotgun: Could not start engine: %s" % e)
+        return
+    
+    file_to_open = os.environ.get("TANK_FILE_TO_OPEN")
+    if file_to_open:
+        # finally open the file
+        cmds.file(file_to_open, force=True, open=True)
+
+    # clean up temp env vars
+    for var in ["TANK_ENGINE", "TANK_CONTEXT", "TANK_FILE_TO_OPEN"]:
+        if var in os.environ:
+            del os.environ[var]
+
+
+cmds.evalDeferred("bootstrap_tank()")
+

--- a/startup/userSetup.py
+++ b/startup/userSetup.py
@@ -17,7 +17,7 @@ import os
 import maya.OpenMaya as OpenMaya
 import maya.cmds as cmds
 
-def bootstrap_sgtk_from_env():
+def start_toolkit_classic():
     """
     Parse enviornment variables for an engine name and
     serialized Context to use to startup Toolkit and
@@ -67,7 +67,7 @@ def bootstrap_sgtk_from_env():
         return
 
 
-def load_sgtk_plugins():
+def start_toolkit_with_plugins():
     """
     Parse environment variables for a list of plugins to load that will
     ultimately startup Toolkit and the tk-maya engine and environment.
@@ -82,7 +82,7 @@ def load_sgtk_plugins():
         else:
             load_path = plugin_path
 
-        # Display a message indicating what path plugins are 
+        # Display a message indicating what path plugins are
         # being loaded from.
         OpenMaya.MGlobal.displayInfo(
             "Shotgun: Loading plugins from '%s'" % load_path
@@ -95,10 +95,6 @@ def load_sgtk_plugins():
                 "Shotgun: No plugins loaded from '%s'" % load_path
             )
             continue
-
-        # Set the newly loaded plugins to autoload.
-        for loaded_plugin in loaded_plugins:
-            cmds.pluginInfo(loaded_plugin, e=True, autoload=True)
 
 
 def start_toolkit():
@@ -114,13 +110,13 @@ def start_toolkit():
         OpenMaya.MGlobal.displayInfo(
             "Shotgun: Loading Toolkit plugins ..."
         )
-        load_sgtk_plugins()
+        start_toolkit_with_plugins()
     else:
         # Rely on the classic boostrapping method
         OpenMaya.MGlobal.displayInfo(
             "Shotgun: Bootstrapping Toolkit from environmment variables ..."
         )
-        bootstrap_sgtk_from_env()
+        start_toolkit_classic()
 
     # Check if a file was specified to open and open it.
     file_to_open = os.environ.get("SGTK_FILE_TO_OPEN")

--- a/startup/userSetup.py
+++ b/startup/userSetup.py
@@ -53,6 +53,11 @@ def bootstrap_tank():
         if var in os.environ:
             del os.environ[var]
 
+def start_toolkit():
+    if os.environ.get("TANK_LOAD_MAYA_PLUGINS"):
 
-cmds.evalDeferred("bootstrap_tank()")
+    else:
+        bootstrap_tank()
 
+
+cmds.evalDeferred("start_toolkit()")

--- a/startup/userSetup.py
+++ b/startup/userSetup.py
@@ -17,13 +17,12 @@ import os
 import maya.OpenMaya as OpenMaya
 import maya.cmds as cmds
 
-print "Sourcing /shotgun/gitrepos/tk-maya/startup/userSetup.py"
 
 def bootstrap_sgtk_from_env():
     """
     Parse enviornment variables for an engine name and
-    serialized Context to use to startup a Toolkit Engine
-    and environment.
+    serialized Context to use to startup Toolkit and
+    the tk-maya engine and environment.
     """
     # Verify sgtk can be loaded.
     try:
@@ -68,7 +67,12 @@ def bootstrap_sgtk_from_env():
         )
         return
 
+
 def load_sgtk_plugins():
+    """
+    Parse environment variables for a list of plugins to load that will
+    ultimately startup Toolkit and the tk-maya engine and environment.
+    """
     for plugin_path in os.environ["SGTK_LOAD_MAYA_PLUGINS"].split(os.pathsep):
         # Find the appropriate "plugin" sub directory. Maya will not be
         # able to find any plugins under the base directory without this.
@@ -99,29 +103,35 @@ def load_sgtk_plugins():
 
 
 def start_toolkit():
+    """
+    Import Toolkit and start up a tk-maya engine based on
+    environment variables.
+    """
     OpenMaya.MGlobal.displayInfo(
         "Shotgun: Starting up Toolkit"
     )
     if os.environ.get("SGTK_LOAD_MAYA_PLUGINS"):
+        # Plugins will take care of initalizing everything
         OpenMaya.MGlobal.displayInfo(
             "Shotgun: Loading Toolkit plugins ..."
         )
         load_sgtk_plugins()
     else:
+        # Rely on the classic boostrapping method
         OpenMaya.MGlobal.displayInfo(
             "Shotgun: Bootstrapping Toolkit from environmment variables ..."
         )
         bootstrap_sgtk_from_env()
 
+    # Check if a file was specified to open and open it.
     file_to_open = os.environ.get("SGTK_FILE_TO_OPEN")
     if file_to_open:
-        # finally open the file
         OpenMaya.MGlobal.displayInfo(
             "Shotgun: Opening '%s' ..." % file_to_open
         )
         cmds.file(file_to_open, force=True, open=True)
 
-    # clean up temp env vars
+    # Clean up temp env variables.
     del_vars = [
         "SGTK_ENGINE", "SGTK_CONTEXT", "SGTK_FILE_TO_OPEN",
         "SGTK_LOAD_MAYA_PLUGINS",

--- a/startup/userSetup.py
+++ b/startup/userSetup.py
@@ -19,7 +19,7 @@ import maya.cmds as cmds
 
 print "Sourcing /shotgun/gitrepos/tk-maya/startup/userSetup.py"
 
-def bootstrap_sgtk():
+def bootstrap_sgtk_from_env():
     """
     Parse enviornment variables for an engine name and
     serialized Context to use to startup a Toolkit Engine
@@ -72,10 +72,10 @@ def load_sgtk_plugins():
     for plugin_path in os.environ["SGTK_LOAD_MAYA_PLUGINS"].split(os.pathsep):
         # Find the appropriate "plugin" sub directory. Maya will not be
         # able to find any plugins under the base directory without this.
-        if os.path.isdir(os.join(plugin_path, "plug-ins")):
-            load_path = os.join(plugin_path, "plug-ins")
-        elif os.path.isdir(os.join(plugin_path, "plugins")):
-            load_path = os.join(plugin_path, "plugins")
+        if os.path.isdir(os.path.join(plugin_path, "plug-ins")):
+            load_path = os.path.join(plugin_path, "plug-ins")
+        elif os.path.isdir(os.path.join(plugin_path, "plugins")):
+            load_path = os.path.join(plugin_path, "plugins")
         else:
             load_path = plugin_path
 
@@ -109,9 +109,9 @@ def start_toolkit():
         load_sgtk_plugins()
     else:
         OpenMaya.MGlobal.displayInfo(
-            "Shotgun: Bootstrapping Toolkit ..."
+            "Shotgun: Bootstrapping Toolkit from environmment variables ..."
         )
-        bootstrap_sgtk()
+        bootstrap_sgtk_from_env()
 
     file_to_open = os.environ.get("SGTK_FILE_TO_OPEN")
     if file_to_open:
@@ -128,7 +128,7 @@ def start_toolkit():
     ]
     for var in del_vars:
         if var in os.environ:
-            del os.environ(var)
+            del os.environ[var]
 
 
 # Fire up Toolkit and the environment engine when there's time.


### PR DESCRIPTION
Use the 'launch_builtin_plugin' engine setting value to determine which, if any, plugins to load when Maya launches.  If no plugins are found to load, fallback on bootstrapping the tk-maya engine from the environment instead. 