### PR TITLE
#40170: Fix Shotgun app panels not restoring in Maya 2017.

### DIFF
--- a/python/tk_maya/__init__.py
+++ b/python/tk_maya/__init__.py
@@ -9,4 +9,4 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 from .menu_generation import MenuGenerator
-from .panel_generation import dock_panel
+from . import panel_generation


### PR DESCRIPTION
Restore the persisted Shotgun app panels into their Maya workspace controls in the active Maya 2017 workspace.
