### PR TITLE
#38958 support for plugin and zero config modes + polish

### DIFF
--- a/plugins/basic/README.md
+++ b/plugins/basic/README.md
@@ -16,7 +16,7 @@ via the toolkit launch application, or as a standalone plugin.
 ### Technical Details
 
 This is a Maya Module that enables basic Shotgun integration
-Inside of Maya. The plugin source is located in the [toolkit maya engine repository](https://github.com/shotgunsoftware/tk-maya/tree/develop/plugin/plugins/basic).
+inside Maya. The plugin source is located in the [toolkit maya engine repository](https://github.com/shotgunsoftware/tk-maya/tree/develop/plugin/plugins/basic).
 Maya version 2014 and above are supported.
 You can read more about maya modules [here](http://help.autodesk.com/view/MAYAUL/2017/ENU/?guid=__files_GUID_CB76E356_753B_4837_8C5B_3296C14872CA_htm).
 

--- a/plugins/basic/README.md
+++ b/plugins/basic/README.md
@@ -4,43 +4,54 @@ This is a Shotgun Pipeline Toolkit plugin,
 embedding the Shotgun Pipeline Toolkit and allowing
 you to easily run and deploy Toolkit Apps and Engines.
 
+The plugin will appear as `shotgun.py` inside of Maya
+and will load the `tk-config-basic` configuration.
 
+It is auto-updating and will attempt to check for new
+versions of this configuration during startup.
 
-## Using the Plugin
+The plugin can either run directly from the engine,
+via the toolkit launch application, or as a standalone plugin.
+
+### Technical Details
 
 This is a Maya Module that enables basic Shotgun integration
-Inside of Maya. Maya version 2014 and above are supported.
+Inside of Maya. The plugin source is located in the [toolkit maya engine repository](https://github.com/shotgunsoftware/tk-maya/tree/develop/plugin/plugins/basic).
+Maya version 2014 and above are supported.
+You can read more about maya modules [here](http://help.autodesk.com/view/MAYAUL/2017/ENU/?guid=__files_GUID_CB76E356_753B_4837_8C5B_3296C14872CA_htm).
 
-### Adding to MAYA_MODULE_PATH
 
-The easiest way to get the plugin loaded is to add an entry to the 
-`MAYA_MODULE_PATH`. For example, if you have unzipped the plugin into
-a `/Users/john.smith/Documents/toolkit_maya_plugin`, simply execute
+# Engine-based plugin
+
+If you are using toolkit's application launcher `tk-multi-launchapp`, you can 
+configure this to start up the plugin as part of launching maya.
+
+This is all done as part of the maya engine configuration. Simply include 
+the parameter `launch_builtin_plugin: basic` as part of your engine configuration
+and the launch app will load the plugin whenever maya is launched for that context:
 
 ```
-export MAYA_MODULE_PATH=$MAYA_MODULE_PATH:/Users/john.smith/Documents/toolkit_maya_plugin
+  tk-maya:
+    apps:
+      ...
+
+    launch_builtin_plugin: basic  
+    location:
+      type: app_store
+      name: tk-maya
+      version: v1.2.3
 ```
 
-in a shell and then launch maya from that shell. On windows, you can set up the 
-environment variable in your computer preferences.
 
-### Using a maya.env file
-
-If you are using a `Maya.env` file, you can define the `MAYA_MODULE_PATH`
-environment variable there.
-
-For example, on Linux and Mac OS X: `MAYA_MODULE_PATH=$HOME/my_maya_modules/tk-maya-basic`
-
-For example, on Windows: `MAYA_MODULE_PATH=%HOME%\my_maya_modules\tk-maya-basic`
-
-For more information about Maya plugins and `maya.env`, please see the Maya Documentation.
-
-
-
+# Standalone Plugin
 
 ## Building the plugin
 
-The plugin source is located in the [toolkit maya engine repository](https://github.com/shotgunsoftware/tk-maya/tree/develop/plugin/plugins/basic).
+If you want to run the plugin as a standalone module, you 
+first need to build it. The build process will prepare the 
+plugin for a standalone run and will cache all necessary
+toolkit components in a special `bundle_cache` directory 
+that comes with the plugin.
 
 In order to build it into a plugin which can be loaded into maya, it needs to be 
 built using a [build script](https://github.com/shotgunsoftware/tk-core/blob/master/developer/build_plugin.py)
@@ -79,7 +90,28 @@ python build_plugin.py /tmp/build_example/tk-maya/plugins/basic /tmp/build_examp
 ```
 
 
-### Additional documentation resources
+## Using the plugin
+
+The easiest way to get the plugin loaded is to add an entry to the 
+`MAYA_MODULE_PATH`. 
+
+For example, if you have put the plugin in
+`/Users/john.smith/Documents/shotgun_basic`, just add this path to your existing
+Maya module path and restart maya.
+
+### Using a maya.env file
+
+If you are using a `Maya.env` file, you can define the `MAYA_MODULE_PATH`
+environment variable there.
+
+For example, on Linux and Mac OS X: `MAYA_MODULE_PATH=$HOME/Documents/shotgun_basic`
+
+For example, on Windows: `MAYA_MODULE_PATH=%HOME%\Documents\shotgun_basic`
+
+For more information about Maya plugins and `maya.env`, please see the Maya Documentation.
+
+
+# Additional documentation resources
 
 If you are a developer making changes to this plugin or it's components,
 you may find the following resources useful:

--- a/plugins/basic/info.yml
+++ b/plugins/basic/info.yml
@@ -9,32 +9,6 @@
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
 
-# This file contains the plug-in configuration data that will be packaged
-# into manifest.py by the build_plugin.py script.
-
-
-#
-# Plug-in information recommended values to specify by convention.
-#
-
-# Plug-in name that will prefix the plug-in messaqges displayed in Maya script editor.
-name: "tk-maya-basic"
-
-# Plug-in version number that will be displayed in Maya Plug-in Information window.
-# This plug-in version number and the one in the Maya module file should be synchronised.
-version: "0.0.5"
-
-description:  "Shotgun toolkit integration into a basic plug-in."
-author:       "Shotgun Software"
-organization: "Autodesk Inc."
-contact:      "support@shotgunsoftware.com"
-url:          "https://www.shotgunsoftware.com"
-
-
-#
-# Values required by all plug-ins.
-#
-
 base_configuration:
   # The default configuration that the plugin should use.
   # For documentation and details, see
@@ -49,11 +23,6 @@ base_configuration:
   type: app_store
   name: tk-config-basic
 
-  # For convenience, the following location descriptor lines will be
-  # kept around while the plug-in is still in private development.
-  # type: "dev"
-  # path: "$TK_CONFIG_PLUGINBASIC_ROOT"
-
 # The Plugin Id helps uniquely identify this plugin and can be
 # used to override and customize it. For more information, see
 # http://developer.shotgunsoftware.com/tk-core/bootstrap.html#sgtk.bootstrap.ToolkitManager.plugin_id
@@ -66,12 +35,3 @@ base_configuration:
 plugin_id: "basic.maya"
 
 
-#
-# Values specific to this plug-in.
-#
-
-# Value given to 'sgtk.LogManager().global_debug'.
-debug_logging: true
-
-# Engine used by the plug-in.
-engine_name: "tk-maya"

--- a/plugins/basic/plug-ins/shotgun.py
+++ b/plugins/basic/plug-ins/shotgun.py
@@ -99,7 +99,7 @@ def initializePlugin(mobject):
 
     else:
         # Running as part of the the launch process and as part of zero
-        # config. The launch logic that already started maya has already
+        # config. The launch logic that started maya has already
         # added sgtk to the pythonpath.
         import sgtk
 

--- a/plugins/basic/plug-ins/shotgun.py
+++ b/plugins/basic/plug-ins/shotgun.py
@@ -16,10 +16,7 @@ import maya.cmds as cmds
 import maya.mel as mel
 import maya.utils
 
-
-# List of all the custom Maya commands defined by the plug-in.
-PLUGIN_CMD_LIST = []
-
+PLUGIN_FILENAME = "shotgun.py"
 
 def maya_useNewAPI():
     """
@@ -35,35 +32,39 @@ def initializePlugin(mobject):
     :param mobject: Maya plug-in MObject.
     :raises: Exception raised by maya.api.OpenMaya.MFnPlugin registerCommand method.
     """
-
     # Make sure the plug-in is running in Maya 2014 or later.
     maya_version = mel.eval("getApplicationVersionAsFloat()")
     if maya_version < 2014:
         msg = "The Shotgun plug-in is not compatible with version %s of Maya; it requires Maya 2014 or later."
         OpenMaya2.MGlobal.displayError(msg % maya_version)
         # Ask Maya to unload the plug-in after returning from here.
-        maya.utils.executeDeferred(cmds.unloadPlugin, "shotgun.py")
+        maya.utils.executeDeferred(cmds.unloadPlugin, PLUGIN_FILENAME)
         # Use the plug-in version to indicate that uninitialization should not be done when unloading it,
         # while keeping in mind that this version can be displayed in Maya Plug-in Information window.
         OpenMaya2.MFnPlugin(mobject, version="Unknown")
         # Return to Maya without further initializing the plug-in.
         return
 
-    # Make sure the Shotgun toolkit has not been loaded by a custom setup
-    # brought forth by Shotgun Desktop or another pipeline tool.
-    if "TK_MAYA_BASIC_SGTK" not in os.environ and "tank" in sys.modules:
-        msg = "The Shotgun plug-in cannot be loaded because Shotgun Toolkit is already running. " \
-              "Maya was launched from Shotgun Desktop or a custom Shotgun Toolkit setup."
-        OpenMaya2.MGlobal.displayError(msg)
-        # Ask Maya to unload the plug-in after returning from here.
-        maya.utils.executeDeferred(cmds.unloadPlugin, "shotgun.py")
-        # Use the plug-in version to indicate that uninitialization should not be done when unloading it,
-        # while keeping in mind that this version can be displayed in Maya Plug-in Information window.
-        OpenMaya2.MFnPlugin(mobject, version="Unknown")
-        # Return to Maya without futher initializing the plug-in.
-        return
+    # We currently don't support running multiple engines
+    # if an engine is already running, exit with an error.
+    try:
+        import sgtk
 
-    # Retrieve the plug-in root directory path.
+        if sgtk.platform.current_engine():
+            msg = "The Shotgun plug-in cannot be loaded because Shotgun Toolkit is already running."
+            OpenMaya2.MGlobal.displayError(msg)
+            # Ask Maya to unload the plug-in after returning from here.
+            maya.utils.executeDeferred(cmds.unloadPlugin, PLUGIN_FILENAME)
+            # Use the plug-in version to indicate that uninitialization should not be done when unloading it,
+            # while keeping in mind that this version can be displayed in Maya Plug-in Information window.
+            OpenMaya2.MFnPlugin(mobject, version="Unknown")
+            # Return to Maya without further initializing the plug-in.
+            return
+    except ImportError:
+        # no sgtk available
+        pass
+
+    # Retrieve the plug-in root directory path, set by the module
     plugin_root_path = os.environ.get("TK_MAYA_BASIC_ROOT")
 
     # Prepend the plug-in python package path to the python module search path.
@@ -71,39 +72,54 @@ def initializePlugin(mobject):
     if plugin_python_path not in sys.path:
         sys.path.insert(0, plugin_python_path)
 
-    from sgtk_plugin_basic_maya import manifest
+    # --- Import Core ---
+    #
+    # - If we are running the plugin built as a stand-alone unit,
+    #   try to retrieve the path to sgtk core and add that to the pythonpath.
+    #   When the plugin has been built, there is a sgtk_plugin_basic_maya
+    #   module which we can use to retrieve the location of core and add it
+    #   to the pythonpath.
+    # - If we are running toolkit as part of a larger zero config workflow
+    #   and not from a standalone workflow, we are running the plugin code
+    #   directly from the engine folder without a bundle cache and with this
+    #   configuration, core already exists in the pythonpath.
 
-    # Retrieve the Shotgun toolkit core included with the plug-in and
-    # prepend its python package path to the python module search path.
-    tkcore_python_path = manifest.get_sgtk_pythonpath(plugin_root_path)
-    if tkcore_python_path not in sys.path:
+    try:
+        from sgtk_plugin_basic_maya import manifest
+        running_as_standalone_plugin = True
+    except ImportError:
+        running_as_standalone_plugin = False
+
+    if running_as_standalone_plugin:
+        # Retrieve the Shotgun toolkit core included with the plug-in and
+        # prepend its python package path to the python module search path.
+        tkcore_python_path = manifest.get_sgtk_pythonpath(plugin_root_path)
         sys.path.insert(0, tkcore_python_path)
+        import sgtk
+
+    else:
+        # Running as part of the the launch process and as part of zero
+        # config. The launch logic that already started maya has already
+        # added sgtk to the pythonpath.
+        import sgtk
+
+    # as early as possible, start up logging to the backend file
+    sgtk.LogManager().initialize_base_file_handler("tk-maya")
 
     # Set the plug-in root directory path constant of the plug-in python package.
-    import tk_maya_basic
-    tk_maya_basic.PLUGIN_ROOT_PATH = plugin_root_path
+    from tk_maya_basic import constants
+    from tk_maya_basic import plugin_logic
 
     # Set the plug-in vendor name and version number to display in Maya Plug-in Information window
     # alongside the plug-in name set by Maya from the name of this file minus its '.py' extension.
-    plugin = OpenMaya2.MFnPlugin(
-                 mobject,
-                 vendor="%s, %s" % (manifest.author, manifest.organization),
-                 version=manifest.version
-             )
-
-    # Register all the plug-in custom commands.
-    for cmd_class in PLUGIN_CMD_LIST:
-        try:
-            plugin.registerCommand(cmd_class.CMD_NAME, createCmdFunc=cmd_class)
-        except:
-            OpenMaya2.MGlobal.displayError("Failed to register command %s." % cmd_class.CMD_NAME)
+    OpenMaya2.MFnPlugin(
+        mobject,
+        vendor=constants.PLUGIN_AUTHOR,
+        version=constants.PLUGIN_VERSION
+    )
 
     # Bootstrap the plug-in logic once Maya has settled.
-    from tk_maya_basic import plugin_logic
     maya.utils.executeDeferred(plugin_logic.bootstrap)
-
-    # Keep a tag in the environment to remember that the plug-in imported the Shotgun toolkit core.
-    os.environ["TK_MAYA_BASIC_SGTK"] = tkcore_python_path
 
 
 def uninitializePlugin(mobject):
@@ -113,7 +129,6 @@ def uninitializePlugin(mobject):
     :param mobject: Maya plug-in MObject.
     :raises: Exception raised by maya.api.OpenMaya.MFnPlugin deregisterCommand method.
     """
-
     plugin = OpenMaya2.MFnPlugin(mobject)
 
     if plugin.version == "Unknown":
@@ -125,9 +140,3 @@ def uninitializePlugin(mobject):
     from tk_maya_basic import plugin_logic
     plugin_logic.shutdown()
 
-    # Deregister all the plug-in custom commands.
-    for cmd_class in PLUGIN_CMD_LIST:
-        try:
-            plugin.deregisterCommand(cmd_class.CMD_NAME)
-        except:
-            OpenMaya2.MGlobal.displayError("Failed to deregister command %s." % cmd_class.CMD_NAME)

--- a/plugins/basic/python/tk_maya_basic/__init__.py
+++ b/plugins/basic/python/tk_maya_basic/__init__.py
@@ -7,6 +7,3 @@
 # By accessing, using, copying or modifying this work you indicate your
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
-
-# Plug-in root directory path constant set when the plug-in is loaded.
-PLUGIN_ROOT_PATH = None

--- a/plugins/basic/python/tk_maya_basic/constants.py
+++ b/plugins/basic/python/tk_maya_basic/constants.py
@@ -1,0 +1,24 @@
+# Copyright (c) 2017 Shotgun Software Inc.
+#
+# CONFIDENTIAL AND PROPRIETARY
+#
+# This work is provided "AS IS" and subject to the Shotgun Pipeline Toolkit
+# Source Code License included in this distribution package. See LICENSE.
+# By accessing, using, copying or modifying this work you indicate your
+# agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
+# not expressly granted therein are reserved by Shotgun Software Inc.
+
+# the constants associated with this plugin
+
+# the version number for this maya plugin - displayed in the maya plugin dialog
+PLUGIN_VERSION = "1.0.0"
+# the author of this maya plugin - displayed in the maya plugin dialog
+PLUGIN_AUTHOR = "Shotgun Software"
+
+# the plugin id to identify this plugin with at bootstrap
+PLUGIN_ID = "basic.maya"
+# the configuration to fall back on if no customization has been provided
+BASE_CONFIGURATION = {"type": "app_store", "name": "tk-config-basic"}
+
+
+

--- a/plugins/basic/python/tk_maya_basic/plugin_engine.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_engine.py
@@ -120,4 +120,4 @@ def shutdown():
         engine.destroy()
 
     else:
-        logger.debug("The maya engine was already stopped!")
+        logger.debug("The Shotgun engine was already stopped!")

--- a/plugins/basic/python/tk_maya_basic/plugin_engine.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_engine.py
@@ -10,11 +10,10 @@
 
 import os
 
-from sgtk_plugin_basic_maya import manifest
+from . import constants
 from . import plugin_logging
 
 from . import __name__ as PLUGIN_PACKAGE_NAME
-from . import PLUGIN_ROOT_PATH
 
 
 def bootstrap(sg_user, progress_callback, completed_callback, failed_callback):
@@ -32,20 +31,17 @@ def bootstrap(sg_user, progress_callback, completed_callback, failed_callback):
     import sgtk
 
     # Use a custom logging handler to display messages in Maya script editor before the engine takes over logging.
-    plugin_logging_handler = plugin_logging.PluginLoggingHandler(manifest.name)
-
-    sgtk.LogManager().initialize_base_file_handler(manifest.engine_name)
+    plugin_logging_handler = plugin_logging.PluginLoggingHandler()
     sgtk.LogManager().initialize_custom_handler(plugin_logging_handler)
-
-    sgtk.LogManager().global_debug = bool(manifest.debug_logging)
 
     logger = sgtk.LogManager.get_logger(PLUGIN_PACKAGE_NAME)
 
     # Create a boostrap manager for the logged in user with the plug-in configuration data.
     toolkit_mgr = sgtk.bootstrap.ToolkitManager(sg_user)
-
-    # Pass the boostrap manager to the manifest for basic initialization.
-    manifest.initialize_manager(toolkit_mgr, PLUGIN_ROOT_PATH)
+    toolkit_mgr.base_configuration = constants.BASE_CONFIGURATION
+    toolkit_mgr.plugin_id = constants.PLUGIN_ID
+    plugin_root_path = os.environ.get("TK_MAYA_BASIC_ROOT")
+    toolkit_mgr.bundle_cache_fallback_paths = [os.path.join(plugin_root_path, "bundle_cache")]
 
     # Retrieve the Shotgun entity type and id when they exist in the environment.
     shotgun_site = os.environ.get("SHOTGUN_SITE")
@@ -87,53 +83,23 @@ def bootstrap(sg_user, progress_callback, completed_callback, failed_callback):
 
     logger.debug("Will launch the engine with entity: %s" % entity)
 
-    # Check if the target core supports asynchronous Shotgun initialization.
-    can_bootstrap_engine_async = hasattr(toolkit_mgr, "bootstrap_engine_async")
-    if not can_bootstrap_engine_async:
-        # Display the warning before the custom logging handler is removed.
-        logger.warning("Cannot initialize Shotgun asynchronously with the loaded toolkit core version;"
-                       " falling back on synchronous startup.")
-
     # Remove the custom logging handler now that the engine will take over logging.
     sgtk.LogManager().root_logger.removeHandler(plugin_logging_handler)
 
-    if can_bootstrap_engine_async:
+    # Install the bootstrap progress reporting callback.
+    toolkit_mgr.progress_callback = progress_callback
 
-        # Install the bootstrap progress reporting callback.
-        toolkit_mgr.progress_callback = progress_callback
+    # Bootstrap a toolkit instance asynchronously in a background thread,
+    # followed by launching the engine synchronously in the main application thread.
+    # Before bootstrapping the engine for the first time around,
+    # the toolkit manager may swap the toolkit core to its latest version.
+    toolkit_mgr.bootstrap_engine_async(
+        "tk-maya",
+        entity,
+        completed_callback=completed_callback,
+        failed_callback=failed_callback
+    )
 
-        # Bootstrap a toolkit instance asynchronously in a background thread,
-        # followed by launching the engine synchronously in the main application thread.
-        # Before bootstrapping the engine for the first time around,
-        # the toolkit manager may swap the toolkit core to its latest version.
-        toolkit_mgr.bootstrap_engine_async(
-            manifest.engine_name,
-            entity,
-            completed_callback=completed_callback,
-            failed_callback=failed_callback
-        )
-
-    else:
-
-        # The imported version of the toolkit core is too old to provide asynchronous bootstrapping.
-        # Fall back on synchronous bootstrapping of the engine in the main application thread,
-        # while still calling the provided callbacks in order for the plug-in to work as expected.
-        # Note that the provided progress reporting callback cannot be used since
-        # this older version of the toolkit core expects a differend callback signature.
-
-        try:
-
-            engine = toolkit_mgr.bootstrap_engine(manifest.engine_name, entity)
-
-        except Exception, exception:
-
-            # Handle cleanup after failed completion of the engine bootstrap.
-            failed_callback(None, exception)
-
-            return
-
-        # Handle cleanup after successful completion of the engine bootstrap.
-        completed_callback(engine)
 
 
 def shutdown():
@@ -143,20 +109,15 @@ def shutdown():
 
     # Re-import the toolkit core to ensure usage of a swapped in version.
     import sgtk
-
     logger = sgtk.LogManager.get_logger(PLUGIN_PACKAGE_NAME)
-
     engine = sgtk.platform.current_engine()
 
     if engine:
-
-        logger.info("Stopping the %s engine." % manifest.engine_name)
-
+        logger.info("Stopping the Shotgun engine.")
         # Close the various windows (dialogs, panels, etc.) opened by the engine.
         engine.close_windows()
-
         # Turn off your engine! Step away from the car!
         engine.destroy()
 
     else:
-        logger.warning("The %s engine is already stopped!" % manifest.engine_name)
+        logger.debug("The maya engine was already stopped!")

--- a/plugins/basic/python/tk_maya_basic/plugin_logging.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logging.py
@@ -19,7 +19,7 @@ class PluginLoggingHandler(logging.Handler):
     Custom logging handler to display plug-in logging records in Maya script editor in a thread safe manner.
     """
 
-    def __init__(self, plugin_name):
+    def __init__(self):
         """
         Initializes an instance of the plug-in logging handler.
 
@@ -29,10 +29,8 @@ class PluginLoggingHandler(logging.Handler):
         # Avoid using super() in order to be compatible with old-style classes found in older versions of logging.
         logging.Handler.__init__(self)
 
-        self._plugin_name = plugin_name
-
         # Set the handler to use a standard message format similar to the one used by the engine.
-        logging_format = "Shotgun [%(levelname)s %(basename)s]: %(message)s"
+        logging_format = "Shotgun: %(message)s"
         self.setFormatter(logging.Formatter(logging_format))
 
     def emit(self, record):
@@ -43,15 +41,10 @@ class PluginLoggingHandler(logging.Handler):
 
         :param record: Logging record to display in Maya script editor.
         """
-
-        # Set the logging format basename to be the plug-in name.
-        record.basename = self._plugin_name
-
         # Give a standard format to the message.
         msg = self.format(record)
 
         # Display the message in Maya script editor in a thread safe manner.
-
         if record.levelno < logging.WARNING:
             fct = OpenMaya2.MGlobal.displayInfo
         elif record.levelno < logging.ERROR:

--- a/plugins/basic/python/tk_maya_basic/plugin_logic.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logic.py
@@ -265,14 +265,14 @@ def _delete_login_menu():
 
 def _jump_to_website():
     """
-    Jumps to the Shotgun website in the defaul web browser.
+    Jumps to the Shotgun website in the default web browser.
     """
     QtGui.QDesktopServices.openUrl(QtCore.QUrl("https://www.shotgunsoftware.com"))
 
 
 def _jump_to_signup():
     """
-    Jumps to the Shotgun website in the defaul web browser.
+    Jumps to the Shotgun signup page in the default web browser.
     """
     QtGui.QDesktopServices.openUrl(QtCore.QUrl("https://www.shotgunsoftware.com/signup"))
 

--- a/plugins/basic/python/tk_maya_basic/plugin_logic.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logic.py
@@ -25,22 +25,12 @@ qt_importer = QtImporter()
 QtCore = qt_importer.QtCore
 QtGui = qt_importer.QtGui
 
-from sgtk_plugin_basic_maya import manifest
 from . import plugin_engine
 from . import plugin_logging
-
 from . import __name__ as PLUGIN_PACKAGE_NAME
-
 
 MENU_LOGIN = "ShotgunMenuLogin"
 MENU_LABEL = "Shotgun"
-
-ITEM_LABEL_LOGIN   = "Log In to Shotgun..."
-ITEM_LABEL_LOGOUT  = "Log Out of Shotgun"
-ITEM_LABEL_WEBSITE = "Learn about Shotgun..."
-
-WEBSITE_URL = "https://shotgunsoftware.com"
-
 
 # Initialize a standalone logger to display messages in Maya script editor
 # when the engine is not running while the user is logged out of Shotgun.
@@ -50,14 +40,13 @@ standalone_logger.propagate = False
 # Ignore messages less severe than the debug ones.
 standalone_logger.setLevel(logging.DEBUG)
 # Use a custom logging handler to display messages in Maya script editor.
-standalone_logger.addHandler(plugin_logging.PluginLoggingHandler(manifest.name))
+standalone_logger.addHandler(plugin_logging.PluginLoggingHandler())
 
 
 def bootstrap():
     """
     Bootstraps the plug-in logic handling user login and logout.
     """
-
     if sgtk.authentication.ShotgunAuthenticator().get_default_user():
         # When the user is already authenticated, automatically log him/her in.
         _login_user()
@@ -101,20 +90,23 @@ def _login_user():
     # processed before deleting the menu to avoid a crash in Maya 2017.
     maya.utils.executeDeferred(_delete_login_menu)
 
-    # Report starting of the bootstrap.
-    standalone_logger.info("Shotgun initialization starting.")
-
     # Show a progress bar, and set its initial value and message.
-    _show_progress_bar(0.0, "Initializing Shotgun...")
+    _show_progress_bar(0.0, "Loading...")
 
     # Before bootstrapping the engine for the first time around,
     # the toolkit manager may swap the toolkit core to its latest version.
-    plugin_engine.bootstrap(
-        user,
-        progress_callback=_handle_bootstrap_progress,
-        completed_callback=_handle_bootstrap_completed,
-        failed_callback=_handle_bootstrap_failed
-    )
+    try:
+        plugin_engine.bootstrap(
+            user,
+            progress_callback=_handle_bootstrap_progress,
+            completed_callback=_handle_bootstrap_completed,
+            failed_callback=_handle_bootstrap_failed
+        )
+    except Exception, e:
+        # return to normal state
+        _handle_bootstrap_failed(phase=None, exception=e)
+        # also print the full call stack
+        standalone_logger.exception("Shotgun reported the following exception during startup:")
 
 
 def _handle_bootstrap_progress(progress_value, message):
@@ -126,17 +118,7 @@ def _handle_bootstrap_progress(progress_value, message):
     :param progress_value: Current progress value, ranging from 0.0 to 1.0.
     :param message: Progress message to report.
     """
-
-    message = "Initializing Shotgun: %s" % message
-
-    standalone_logger.info(message)
-
-    # Show the progress bar, and update its value and message.
     _show_progress_bar(progress_value, message)
-
-    # Force Maya to process its UI events in order to refresh the main progress bar.
-    #qApp = QtCore.QCoreApplication.instance()
-    #qApp.processEvents()
 
 
 def _handle_bootstrap_completed(engine):
@@ -158,11 +140,11 @@ def _handle_bootstrap_completed(engine):
     _hide_progress_bar()
 
     # Report completion of the bootstrap.
-    standalone_logger.info("Shotgun initialization completed.")
+    standalone_logger.info("Integration Loaded.")
 
     # Add a logout menu item to the engine context menu.
     sgtk.platform.current_engine().register_command(
-        ITEM_LABEL_LOGOUT,
+        "Log Out of Shotgun",
         _logout_user,
         {"type": "context_menu"}
     )
@@ -190,7 +172,7 @@ def _handle_bootstrap_failed(phase, exception):
     _hide_progress_bar()
 
     # Report the encountered exception.
-    standalone_logger.error("Shotgun initialization failed: %s" % exception)
+    standalone_logger.error("Initialization failed: %s" % exception)
 
     # Clear the user's credentials to log him/her out.
     sgtk.authentication.ShotgunAuthenticator().clear_default_user()
@@ -229,7 +211,7 @@ def _show_progress_bar(progress_value, message):
 
     # Set the main progress bar value and message.
     main_progress_bar.setProgress(int(progress_value * 100.0))
-    main_progress_bar.setStatus(message)
+    main_progress_bar.setStatus("Shotgun: %s" % message)
 
 
 def _hide_progress_bar():
@@ -251,10 +233,25 @@ def _create_login_menu():
     menu = pm.menu(MENU_LOGIN, label=MENU_LABEL, parent=pm.melGlobals["gMainWindow"])
 
     # Add the login menu item.
-    pm.menuItem(parent=menu, label=ITEM_LABEL_LOGIN, command=pm.Callback(_login_user))
+    pm.menuItem(
+        parent=menu,
+        label="Log In to Shotgun...",
+        command=pm.Callback(_login_user)
+    )
+
+    pm.menuItem(parent=menu, divider=True)
 
     # Add the website menu item.
-    pm.menuItem(parent=menu, label=ITEM_LABEL_WEBSITE, command=pm.Callback(_jump_to_website))
+    pm.menuItem(
+        parent=menu,
+        label="Learn about Shotgun...",
+        command=pm.Callback(_jump_to_website)
+    )
+    pm.menuItem(
+        parent=menu,
+        label="Try Shotgun for Free...",
+        command=pm.Callback(_jump_to_signup)
+    )
 
 
 def _delete_login_menu():
@@ -270,5 +267,12 @@ def _jump_to_website():
     """
     Jumps to the Shotgun website in the defaul web browser.
     """
+    QtGui.QDesktopServices.openUrl(QtCore.QUrl("https://www.shotgunsoftware.com"))
 
-    QtGui.QDesktopServices.openUrl(QtCore.QUrl(WEBSITE_URL))
+
+def _jump_to_signup():
+    """
+    Jumps to the Shotgun website in the defaul web browser.
+    """
+    QtGui.QDesktopServices.openUrl(QtCore.QUrl("https://www.shotgunsoftware.com/signup"))
+

--- a/plugins/basic/shotgun.mod
+++ b/plugins/basic/shotgun.mod
@@ -8,5 +8,5 @@
 # agreement to the Shotgun Pipeline Toolkit Source Code License. All rights
 # not expressly granted therein are reserved by Shotgun Software Inc.
 
-+ tk-maya-basic 0.0.5 .
++ tk-maya-basic 1.0.0 .
 TK_MAYA_BASIC_ROOT:=.

--- a/startup.py
+++ b/startup.py
@@ -110,7 +110,7 @@ class MayaLauncher(SoftwareLauncher):
                     # If the plugin path exists, add it to the list of MAYA_MODULE_PATHS
                     # so Maya can find it and to the list of SGTK_LOAD_MAYA_PLUGINS so
                     # the startup's userSetup.py file knows what plugins to load.
-                    self.logger.info("Loading builtin plugin '%s'" % load_plugin)
+                    self.logger.debug("Preparing to launch builtin plugin '%s'" % load_plugin)
                     load_maya_plugins.append(load_plugin)
                     if load_plugin not in maya_module_paths:
                         maya_module_paths.append(load_plugin)

--- a/startup/userSetup.py
+++ b/startup/userSetup.py
@@ -23,14 +23,10 @@ def start_toolkit_classic():
     serialized Context to use to startup Toolkit and
     the tk-maya engine and environment.
     """
-    # Verify sgtk can be loaded.
-    try:
-        import sgtk
-    except Exception, e:
-        OpenMaya.MGlobal.displayError(
-            "Shotgun: Could not import sgtk! Disabling for now: %s" % e
-        )
-        return
+    import sgtk
+    logger = sgtk.LogManager.get_logger(__name__)
+
+    logger.debug("Launching toolkit in classic mode.")
 
     # Get the name of the engine to start from the environement
     env_engine = os.environ.get("SGTK_ENGINE")
@@ -59,6 +55,7 @@ def start_toolkit_classic():
 
     try:
         # Start up the toolkit engine from the environment data
+        logger.debug("Launching engine instance '%s' for context %s" % (env_engine, env_context))
         engine = sgtk.platform.start_engine(env_engine, context.sgtk, context)
     except Exception, e:
         OpenMaya.MGlobal.displayError(
@@ -72,6 +69,11 @@ def start_toolkit_with_plugins():
     Parse environment variables for a list of plugins to load that will
     ultimately startup Toolkit and the tk-maya engine and environment.
     """
+    import sgtk
+    logger = sgtk.LogManager.get_logger(__name__)
+
+    logger.debug("Launching maya in plugin mode")
+
     for plugin_path in os.environ["SGTK_LOAD_MAYA_PLUGINS"].split(os.pathsep):
         # Find the appropriate "plugin" sub directory. Maya will not be
         # able to find any plugins under the base directory without this.
@@ -82,12 +84,6 @@ def start_toolkit_with_plugins():
         else:
             load_path = plugin_path
 
-        # Display a message indicating what path plugins are
-        # being loaded from.
-        OpenMaya.MGlobal.displayInfo(
-            "Shotgun: Loading plugins from '%s'" % load_path
-        )
-
         # Load the plugins from the resolved path individually, as the
         # loadPlugin Maya command has difficulties loading all (*) plugins
         # from a path that contains a string in the form of 'v#.#.#':
@@ -95,22 +91,22 @@ def start_toolkit_with_plugins():
         #   // Error: line 1: Plug-in, "/shotgun/site/project/install/app_store/tk-maya/v0.7.10/plugins/basic/plug-ins/*", was not found on MAYA_PLUG_IN_PATH. //
         #   loadPlugin "/shotgun/site/project/install/app_store/tk-maya-no_version/plugins/basic/plug-ins/*";
         #   // Result: shotgun //
-        for plugin in os.listdir(load_path):
-            if not plugin.endswith(".py"):
+        for plugin_filename in os.listdir(load_path):
+            if not plugin_filename.endswith(".py"):
                 # Skip files/directories that are not plugins
                 continue
 
             # Construct the OS agnostic full path to the plugin
             # and attempt to load the plugin. Note that the loadPlugin
             # command always returns a list, even when loading a single plugin.
-            load_plugin = os.path.join(load_path, plugin)
-            OpenMaya.MGlobal.displayInfo(
-                "Shotgun: Attempting to load plugin: %s" % load_plugin
-            )
-            loaded_plugins = cmds.loadPlugin(load_plugin)
+            full_plugin_path = os.path.join(load_path, plugin_filename)
+            logger.debug("Loading plugin %s" % full_plugin_path)
+
+            loaded_plugins = cmds.loadPlugin(full_plugin_path)
+            # note: loadPlugin returns a list of the loaded plugins
             if not loaded_plugins:
                 OpenMaya.MGlobal.displayWarning(
-                    "Shotgun: Could not load plugin: %s" % load_plugin
+                    "Shotgun: Could not load plugin: %s" % full_plugin_path
                 )
                 continue
 
@@ -120,27 +116,31 @@ def start_toolkit():
     Import Toolkit and start up a tk-maya engine based on
     environment variables.
     """
-    OpenMaya.MGlobal.displayInfo(
-        "Shotgun: Starting up Toolkit"
-    )
+
+    # Verify sgtk can be loaded.
+    try:
+        import sgtk
+    except Exception, e:
+        OpenMaya.MGlobal.displayError(
+            "Shotgun: Could not import sgtk! Disabling for now: %s" % e
+        )
+        return
+
+    # start up toolkit logging to file
+    sgtk.LogManager().initialize_base_file_handler("tk-maya")
+
     if os.environ.get("SGTK_LOAD_MAYA_PLUGINS"):
         # Plugins will take care of initalizing everything
-        OpenMaya.MGlobal.displayInfo(
-            "Shotgun: Loading Toolkit plugins ..."
-        )
         start_toolkit_with_plugins()
     else:
         # Rely on the classic boostrapping method
-        OpenMaya.MGlobal.displayInfo(
-            "Shotgun: Bootstrapping Toolkit from environmment variables ..."
-        )
         start_toolkit_classic()
 
     # Check if a file was specified to open and open it.
     file_to_open = os.environ.get("SGTK_FILE_TO_OPEN")
     if file_to_open:
         OpenMaya.MGlobal.displayInfo(
-            "Shotgun: Opening '%s' ..." % file_to_open
+            "Shotgun: Opening '%s'..." % file_to_open
         )
         cmds.file(file_to_open, force=True, open=True)
 


### PR DESCRIPTION
This enables the maya plugin to run both as a zero config "in-situ" part that lives in the engine (with no bundle cache) and as an independent component which can be built and deployed outside the tk eco system.

- The manifest has been cut down in order to enable the duality without having complicated build setups
- the plugin now handles both standalone and in-situ bootstraps
- Logging is less technical in its appearance and less is displayed in the console
- Added a sign up link on the menu if you are not logged in:
![image](https://cloud.githubusercontent.com/assets/337710/22183141/ace8548a-e0ae-11e6-9c72-1244a2f01267.png)
- removed some legacy logic which we won't need for the release
- improved detection of other plugins and tk classic
