### PR TITLE
#40470, Update to scan software fallback logic 

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -305,11 +305,17 @@ class MayaLauncher(SoftwareLauncher):
                 synergy_data.get("StartWrapperPath") or synergy_data["ExecutablePath"]
             )
 
+            # Sometimes the Synergy StringVersion is a bit wordy.
+            # Truncate non essential strings for the display name.
+            synergy_name = None
+            if synergy_data["StringVersion"]:
+                synergy_name = str(synergy_data["StringVersion"]).replace("Autodesk", "").strip()
+
             # Create a SoftwareVersion from input and config data.
             self.logger.debug("Creating SoftwareVersion for '%s'" % exec_path)
             sw_versions.append(SoftwareVersion(
                 synergy_data["NumericVersion"],
-                (synergy_data["StringVersion"] or display_name),
+                (synergy_name or display_name),
                 exec_path,
                 (self._icon_from_executable(exec_path) or icon)
             ))

--- a/startup.py
+++ b/startup.py
@@ -309,9 +309,9 @@ class MayaLauncher(SoftwareLauncher):
             self.logger.debug("Creating SoftwareVersion for '%s'" % exec_path)
             sw_versions.append(SoftwareVersion(
                 synergy_data["NumericVersion"],
-                (display_name or synergy_data["StringVersion"]),
+                (synergy_data["StringVersion"] or display_name),
                 exec_path,
-                (icon or self._icon_from_executable(exec_path))
+                (self._icon_from_executable(exec_path) or icon)
             ))
 
         return sw_versions
@@ -423,9 +423,9 @@ class MayaLauncher(SoftwareLauncher):
                 )
                 sw_versions.append(SoftwareVersion(
                     default_version,
-                    (display_name or default_display),
+                    (default_display or display_name),
                     exec_path,
-                    (icon or self._icon_from_executable(exec_path))
+                    (self._icon_from_executable(exec_path) or icon)
                 ))
 
         return sw_versions


### PR DESCRIPTION
Updates the logic in the `MayaSoftwareLauncher.scan_software()` method to prefer information gathered from disk for the display name and icon of the corresponding launch command that is generated over information that is passed in from a Shotgun Software entity. Prior to this update, this fallback logic was reversed.