### PR TITLE
41526 Remove legacy log_* methods and use engine.logger.* instead.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -242,7 +242,7 @@ class MayaEngine(tank.platform.Engine):
         """
         Initializes the Maya engine.
         """
-        self.logger.debug("%s: Initializing..." % self)
+        self.logger.debug("%s: Initializing...", self)
 
         # check that we are running an ok version of maya
         current_os = cmds.about(operatingSystem=True)
@@ -254,7 +254,7 @@ class MayaEngine(tank.platform.Engine):
         if maya_ver.startswith("Maya "):
             maya_ver = maya_ver[5:]
         if maya_ver.startswith(("2014", "2015", "2016", "2017")):
-            self.logger.debug("Running Maya version %s" % maya_ver)
+            self.logger.debug("Running Maya version %s", maya_ver)
         elif maya_ver.startswith(("2012", "2013")):
             # We won't be able to rely on the warning dialog below, because Maya
             # older than 2014 doesn't ship with PySide. Instead, we just have to
@@ -395,16 +395,16 @@ class MayaEngine(tank.platform.Engine):
 
             if command_dict is None:
                 self.logger.warning(
-                    "%s configuration setting 'run_at_startup' requests app '%s' that is not installed." %
-                    (self.name, app_instance_name))
+                    "%s configuration setting 'run_at_startup' requests app '%s' that is not installed.",
+                    self.name, app_instance_name)
             else:
                 if not setting_command_name:
                     # Run all commands of the given app instance.
                     # Run these commands once Maya will have completed its UI update and be idle
                     # in order to run them after the ones that restore the persisted Shotgun app panels.
                     for (command_name, command_function) in command_dict.iteritems():
-                        self.logger.debug("%s startup running app '%s' command '%s'." %
-                                       (self.name, app_instance_name, command_name))
+                        self.logger.debug("%s startup running app '%s' command '%s'.",
+                                       self.name, app_instance_name, command_name)
                         maya.utils.executeDeferred(command_function)
                 else:
                     # Run the command whose name is listed in the 'run_at_startup' setting.
@@ -412,22 +412,22 @@ class MayaEngine(tank.platform.Engine):
                     # in order to run it after the ones that restore the persisted Shotgun app panels.
                     command_function = command_dict.get(setting_command_name)
                     if command_function:
-                        self.logger.debug("%s startup running app '%s' command '%s'." %
-                                       (self.name, app_instance_name, setting_command_name))
+                        self.logger.debug("%s startup running app '%s' command '%s'.",
+                                       self.name, app_instance_name, setting_command_name)
                         maya.utils.executeDeferred(command_function)
                     else:
                         known_commands = ', '.join("'%s'" % name for name in command_dict)
                         self.logger.warning(
                             "%s configuration setting 'run_at_startup' requests app '%s' unknown command '%s'. "
-                            "Known commands: %s" %
-                            (self.name, app_instance_name, setting_command_name, known_commands))
+                            "Known commands: %s",
+                            self.name, app_instance_name, setting_command_name, known_commands)
 
 
     def destroy_engine(self):
         """
         Stops watching scene events and tears down menu.
         """
-        self.logger.debug("%s: Destroying..." % self)
+        self.logger.debug("%s: Destroying...", self)
 
         # Clear the dictionary of Maya panels to keep the garbage collector happy.
         self._maya_panel_dict = {}
@@ -469,13 +469,13 @@ class MayaEngine(tank.platform.Engine):
 
         if sys.platform == "darwin":
             pyside_path = os.path.join(self.disk_location, "resources","pyside112_py26_qt471_mac", "python")
-            self.logger.debug("Adding pyside to sys.path: %s" % pyside_path)
+            self.logger.debug("Adding pyside to sys.path: %s", pyside_path)
             sys.path.append(pyside_path)
 
         elif sys.platform == "win32":
             # default windows version of pyside for 2011 and 2012
             pyside_path = os.path.join(self.disk_location, "resources","pyside111_py26_qt471_win64", "python")
-            self.logger.debug("Adding pyside to sys.path: %s" % pyside_path)
+            self.logger.debug("Adding pyside to sys.path: %s", pyside_path)
             sys.path.append(pyside_path)
             dll_path = os.path.join(self.disk_location, "resources","pyside111_py26_qt471_win64", "lib")
             path = os.environ.get("PATH", "")
@@ -484,7 +484,7 @@ class MayaEngine(tank.platform.Engine):
 
         elif sys.platform == "linux2":
             pyside_path = os.path.join(self.disk_location, "resources","pyside112_py26_qt471_linux", "python")
-            self.logger.debug("Adding pyside to sys.path: %s" % pyside_path)
+            self.logger.debug("Adding pyside to sys.path: %s", pyside_path)
             sys.path.append(pyside_path)
 
         else:
@@ -495,7 +495,7 @@ class MayaEngine(tank.platform.Engine):
             from PySide import QtGui
         except Exception, e:
             self.logger.error("PySide could not be imported! Apps using pyside will not "
-                           "operate correctly! Error reported: %s" % e)
+                           "operate correctly! Error reported: %s", e)
 
     def _get_dialog_parent(self):
         """
@@ -577,7 +577,7 @@ class MayaEngine(tank.platform.Engine):
         tmpl = self.tank.templates.get(setting)
         fields = self.context.as_template_fields(tmpl)
         proj_path = tmpl.apply_fields(fields)
-        self.logger.info("Setting Maya project to '%s'" % proj_path)
+        self.logger.info("Setting Maya project to '%s'", proj_path)
         pm.mel.setProject(proj_path)
 
     ##########################################################################################
@@ -600,7 +600,7 @@ class MayaEngine(tank.platform.Engine):
 
         tk_maya = self.import_module("tk_maya")
 
-        self.logger.debug("Begin showing panel %s" % panel_id)
+        self.logger.debug("Begin showing panel %s", panel_id)
 
         # The general approach below is as follows:
         #
@@ -631,27 +631,27 @@ class MayaEngine(tank.platform.Engine):
         widget_id = tk_maya.panel_generation.SHOTGUN_APP_PANEL_PREFIX + panel_id
 
         if pm.control(widget_id, query=1, exists=1):
-            self.logger.debug("Reparent existing toolkit widget %s." % widget_id)
+            self.logger.debug("Reparent existing toolkit widget %s.", widget_id)
             # Find the Shotgun app panel widget for later use.
             for widget in QtGui.QApplication.allWidgets():
                 if widget.objectName() == widget_id:
                     widget_instance = widget
                     # Reparent the Shotgun app panel widget under Maya main window
                     # to prevent it from being deleted with the existing Maya panel.
-                    self.logger.debug("Reparenting widget %s under Maya main window." % widget_id)
+                    self.logger.debug("Reparenting widget %s under Maya main window.", widget_id)
                     parent = self._get_dialog_parent()
                     widget_instance.setParent(parent)
                     # The Shotgun app panel was retrieved from under an existing Maya panel.
                     break
         else:
-            self.logger.debug("Create toolkit widget %s" % widget_id)
+            self.logger.debug("Create toolkit widget %s", widget_id)
             # parent the UI to the main maya window
             parent = self._get_dialog_parent()
             widget_instance = widget_class(*args, **kwargs)
             widget_instance.setParent(parent)
             # set its name - this means that it can also be found via the maya API
             widget_instance.setObjectName(widget_id)
-            self.logger.debug("Created widget %s: %s" % (widget_id, widget_instance))
+            self.logger.debug("Created widget %s: %s", widget_id, widget_instance)
             # apply external stylesheet
             self._apply_external_styleshet(bundle, widget_instance)
             # The Shotgun app panel was just created.
@@ -683,10 +683,10 @@ class MayaEngine(tank.platform.Engine):
             dialog_window_title = dialog.windowTitle()
             try:
                 # Close the dialog and let its close callback remove it from the original dialog list.
-                self.logger.debug("Closing dialog %s." % dialog_window_title)
+                self.logger.debug("Closing dialog %s.", dialog_window_title)
                 dialog.close()
             except Exception, exception:
-                self.logger.error("Cannot close dialog %s: %s" % (dialog_window_title, exception))
+                self.logger.error("Cannot close dialog %s: %s", dialog_window_title, exception)
 
         # Loop through the dictionary of Maya panels that have been created by the engine.
         for (maya_panel_name, widget_instance) in self._maya_panel_dict.iteritems():
@@ -695,15 +695,15 @@ class MayaEngine(tank.platform.Engine):
                 try:
                     # Reparent the Shotgun app panel widget under Maya main window
                     # to prevent it from being deleted with the existing Maya panel.
-                    self.logger.debug("Reparenting widget %s under Maya main window." %
+                    self.logger.debug("Reparenting widget %s under Maya main window.",
                                    widget_instance.objectName())
                     parent = self._get_dialog_parent()
                     widget_instance.setParent(parent)
                     # The Maya panel can now be deleted safely.
-                    self.logger.debug("Deleting Maya panel %s." % maya_panel_name)
+                    self.logger.debug("Deleting Maya panel %s.", maya_panel_name)
                     pm.deleteUI(maya_panel_name)
                 except Exception, exception:
-                    self.logger.error("Cannot delete Maya panel %s: %s" % (maya_panel_name, exception))
+                    self.logger.error("Cannot delete Maya panel %s: %s", maya_panel_name, exception)
 
         # Clear the dictionary of Maya panels now that they were deleted.
         self._maya_panel_dict = {}

--- a/engine.py
+++ b/engine.py
@@ -236,13 +236,13 @@ class MayaEngine(tank.platform.Engine):
         # tell QT to interpret C strings as utf-8
         utf8 = QtCore.QTextCodec.codecForName("utf-8")
         QtCore.QTextCodec.setCodecForCStrings(utf8)
-        self.log_debug("set utf-8 codec for widget text")
+        self.logger.debug("set utf-8 codec for widget text")
 
     def init_engine(self):
         """
         Initializes the Maya engine.
         """
-        self.log_debug("%s: Initializing..." % self)
+        self.logger.debug("%s: Initializing..." % self)
 
         # check that we are running an ok version of maya
         current_os = cmds.about(operatingSystem=True)
@@ -254,7 +254,7 @@ class MayaEngine(tank.platform.Engine):
         if maya_ver.startswith("Maya "):
             maya_ver = maya_ver[5:]
         if maya_ver.startswith(("2014", "2015", "2016", "2017")):
-            self.log_debug("Running Maya version %s" % maya_ver)
+            self.logger.debug("Running Maya version %s" % maya_ver)
         elif maya_ver.startswith(("2012", "2013")):
             # We won't be able to rely on the warning dialog below, because Maya
             # older than 2014 doesn't ship with PySide. Instead, we just have to
@@ -288,7 +288,7 @@ class MayaEngine(tank.platform.Engine):
                 cmds.confirmDialog(title = title, message = msg, button = "Ok")
 
             # always log the warning to the script editor:
-            self.log_warning(msg)
+            self.logger.warning(msg)
 
         self._maya_version = maya_ver
 
@@ -314,7 +314,7 @@ class MayaEngine(tank.platform.Engine):
             # need to watch some scene events in case the engine needs rebuilding:
             cb_fn = lambda en=self.instance_name, pc=self.context, mn=self._menu_name:on_scene_event_callback(en, pc, mn)
             self.__watcher = SceneEventWatcher(cb_fn)
-            self.log_debug("Registered open and save callbacks.")
+            self.logger.debug("Registered open and save callbacks.")
 
         # Initialize a dictionary of Maya panels that have been created by the engine.
         # Each panel entry has a Maya panel name key and an app widget instance value.
@@ -361,7 +361,7 @@ class MayaEngine(tank.platform.Engine):
                 menu_name=mn,
             )
             self.__watcher = SceneEventWatcher(cb_fn)
-            self.log_debug(
+            self.logger.debug(
                 "Registered new open and save callbacks before changing context."
             )
 
@@ -394,7 +394,7 @@ class MayaEngine(tank.platform.Engine):
             command_dict = app_instance_commands.get(app_instance_name)
 
             if command_dict is None:
-                self.log_warning(
+                self.logger.warning(
                     "%s configuration setting 'run_at_startup' requests app '%s' that is not installed." %
                     (self.name, app_instance_name))
             else:
@@ -403,7 +403,7 @@ class MayaEngine(tank.platform.Engine):
                     # Run these commands once Maya will have completed its UI update and be idle
                     # in order to run them after the ones that restore the persisted Shotgun app panels.
                     for (command_name, command_function) in command_dict.iteritems():
-                        self.log_debug("%s startup running app '%s' command '%s'." %
+                        self.logger.debug("%s startup running app '%s' command '%s'." %
                                        (self.name, app_instance_name, command_name))
                         maya.utils.executeDeferred(command_function)
                 else:
@@ -412,12 +412,12 @@ class MayaEngine(tank.platform.Engine):
                     # in order to run it after the ones that restore the persisted Shotgun app panels.
                     command_function = command_dict.get(setting_command_name)
                     if command_function:
-                        self.log_debug("%s startup running app '%s' command '%s'." %
+                        self.logger.debug("%s startup running app '%s' command '%s'." %
                                        (self.name, app_instance_name, setting_command_name))
                         maya.utils.executeDeferred(command_function)
                     else:
                         known_commands = ', '.join("'%s'" % name for name in command_dict)
-                        self.log_warning(
+                        self.logger.warning(
                             "%s configuration setting 'run_at_startup' requests app '%s' unknown command '%s'. "
                             "Known commands: %s" %
                             (self.name, app_instance_name, setting_command_name, known_commands))
@@ -427,7 +427,7 @@ class MayaEngine(tank.platform.Engine):
         """
         Stops watching scene events and tears down menu.
         """
-        self.log_debug("%s: Destroying..." % self)
+        self.logger.debug("%s: Destroying..." % self)
 
         # Clear the dictionary of Maya panels to keep the garbage collector happy.
         self._maya_panel_dict = {}
@@ -450,10 +450,10 @@ class MayaEngine(tank.platform.Engine):
             from PySide2 import QtGui
         except:
             # fine, we don't expect PySide2 to be present just yet
-            self.log_debug("PySide2 not detected - trying for PySide now...")
+            self.logger.debug("PySide2 not detected - trying for PySide now...")
         else:
             # looks like pyside2 is already working! No need to do anything
-            self.log_debug("PySide2 detected - the existing version will be used.")
+            self.logger.debug("PySide2 detected - the existing version will be used.")
             return
 
         # then see if pyside is present
@@ -461,21 +461,21 @@ class MayaEngine(tank.platform.Engine):
             from PySide import QtGui
         except:
             # must be a very old version of Maya.
-            self.log_debug("PySide not detected - it will be added to the setup now...")
+            self.logger.debug("PySide not detected - it will be added to the setup now...")
         else:
             # looks like pyside is already working! No need to do anything
-            self.log_debug("PySide detected - the existing version will be used.")
+            self.logger.debug("PySide detected - the existing version will be used.")
             return
 
         if sys.platform == "darwin":
             pyside_path = os.path.join(self.disk_location, "resources","pyside112_py26_qt471_mac", "python")
-            self.log_debug("Adding pyside to sys.path: %s" % pyside_path)
+            self.logger.debug("Adding pyside to sys.path: %s" % pyside_path)
             sys.path.append(pyside_path)
 
         elif sys.platform == "win32":
             # default windows version of pyside for 2011 and 2012
             pyside_path = os.path.join(self.disk_location, "resources","pyside111_py26_qt471_win64", "python")
-            self.log_debug("Adding pyside to sys.path: %s" % pyside_path)
+            self.logger.debug("Adding pyside to sys.path: %s" % pyside_path)
             sys.path.append(pyside_path)
             dll_path = os.path.join(self.disk_location, "resources","pyside111_py26_qt471_win64", "lib")
             path = os.environ.get("PATH", "")
@@ -484,17 +484,17 @@ class MayaEngine(tank.platform.Engine):
 
         elif sys.platform == "linux2":
             pyside_path = os.path.join(self.disk_location, "resources","pyside112_py26_qt471_linux", "python")
-            self.log_debug("Adding pyside to sys.path: %s" % pyside_path)
+            self.logger.debug("Adding pyside to sys.path: %s" % pyside_path)
             sys.path.append(pyside_path)
 
         else:
-            self.log_error("Unknown platform - cannot initialize PySide!")
+            self.logger.error("Unknown platform - cannot initialize PySide!")
 
         # now try to import it
         try:
             from PySide import QtGui
         except Exception, e:
-            self.log_error("PySide could not be imported! Apps using pyside will not "
+            self.logger.error("PySide could not be imported! Apps using pyside will not "
                            "operate correctly! Error reported: %s" % e)
 
     def _get_dialog_parent(self):
@@ -577,7 +577,7 @@ class MayaEngine(tank.platform.Engine):
         tmpl = self.tank.templates.get(setting)
         fields = self.context.as_template_fields(tmpl)
         proj_path = tmpl.apply_fields(fields)
-        self.log_info("Setting Maya project to '%s'" % proj_path)
+        self.logger.info("Setting Maya project to '%s'" % proj_path)
         pm.mel.setProject(proj_path)
 
     ##########################################################################################
@@ -600,7 +600,7 @@ class MayaEngine(tank.platform.Engine):
 
         tk_maya = self.import_module("tk_maya")
 
-        self.log_debug("Begin showing panel %s" % panel_id)
+        self.logger.debug("Begin showing panel %s" % panel_id)
 
         # The general approach below is as follows:
         #
@@ -631,27 +631,27 @@ class MayaEngine(tank.platform.Engine):
         widget_id = tk_maya.panel_generation.SHOTGUN_APP_PANEL_PREFIX + panel_id
 
         if pm.control(widget_id, query=1, exists=1):
-            self.log_debug("Reparent existing toolkit widget %s." % widget_id)
+            self.logger.debug("Reparent existing toolkit widget %s." % widget_id)
             # Find the Shotgun app panel widget for later use.
             for widget in QtGui.QApplication.allWidgets():
                 if widget.objectName() == widget_id:
                     widget_instance = widget
                     # Reparent the Shotgun app panel widget under Maya main window
                     # to prevent it from being deleted with the existing Maya panel.
-                    self.log_debug("Reparenting widget %s under Maya main window." % widget_id)
+                    self.logger.debug("Reparenting widget %s under Maya main window." % widget_id)
                     parent = self._get_dialog_parent()
                     widget_instance.setParent(parent)
                     # The Shotgun app panel was retrieved from under an existing Maya panel.
                     break
         else:
-            self.log_debug("Create toolkit widget %s" % widget_id)
+            self.logger.debug("Create toolkit widget %s" % widget_id)
             # parent the UI to the main maya window
             parent = self._get_dialog_parent()
             widget_instance = widget_class(*args, **kwargs)
             widget_instance.setParent(parent)
             # set its name - this means that it can also be found via the maya API
             widget_instance.setObjectName(widget_id)
-            self.log_debug("Created widget %s: %s" % (widget_id, widget_instance))
+            self.logger.debug("Created widget %s: %s" % (widget_id, widget_instance))
             # apply external stylesheet
             self._apply_external_styleshet(bundle, widget_instance)
             # The Shotgun app panel was just created.
@@ -683,10 +683,10 @@ class MayaEngine(tank.platform.Engine):
             dialog_window_title = dialog.windowTitle()
             try:
                 # Close the dialog and let its close callback remove it from the original dialog list.
-                self.log_debug("Closing dialog %s." % dialog_window_title)
+                self.logger.debug("Closing dialog %s." % dialog_window_title)
                 dialog.close()
             except Exception, exception:
-                self.log_error("Cannot close dialog %s: %s" % (dialog_window_title, exception))
+                self.logger.error("Cannot close dialog %s: %s" % (dialog_window_title, exception))
 
         # Loop through the dictionary of Maya panels that have been created by the engine.
         for (maya_panel_name, widget_instance) in self._maya_panel_dict.iteritems():
@@ -695,15 +695,15 @@ class MayaEngine(tank.platform.Engine):
                 try:
                     # Reparent the Shotgun app panel widget under Maya main window
                     # to prevent it from being deleted with the existing Maya panel.
-                    self.log_debug("Reparenting widget %s under Maya main window." %
+                    self.logger.debug("Reparenting widget %s under Maya main window." %
                                    widget_instance.objectName())
                     parent = self._get_dialog_parent()
                     widget_instance.setParent(parent)
                     # The Maya panel can now be deleted safely.
-                    self.log_debug("Deleting Maya panel %s." % maya_panel_name)
+                    self.logger.debug("Deleting Maya panel %s." % maya_panel_name)
                     pm.deleteUI(maya_panel_name)
                 except Exception, exception:
-                    self.log_error("Cannot delete Maya panel %s: %s" % (maya_panel_name, exception))
+                    self.logger.error("Cannot delete Maya panel %s: %s" % (maya_panel_name, exception))
 
         # Clear the dictionary of Maya panels now that they were deleted.
         self._maya_panel_dict = {}

--- a/python/tk_maya/menu_generation.py
+++ b/python/tk_maya/menu_generation.py
@@ -160,7 +160,7 @@ class MenuGenerator(object):
             
             exit_code = os.system(cmd)
             if exit_code != 0:
-                self._engine.logger.error("Failed to launch '%s'!" % cmd)
+                self._engine.logger.error("Failed to launch '%s'!", cmd)
         
                         
     ##########################################################################################

--- a/python/tk_maya/menu_generation.py
+++ b/python/tk_maya/menu_generation.py
@@ -160,7 +160,7 @@ class MenuGenerator(object):
             
             exit_code = os.system(cmd)
             if exit_code != 0:
-                self._engine.log_error("Failed to launch '%s'!" % cmd)
+                self._engine.logger.error("Failed to launch '%s'!" % cmd)
         
                         
     ##########################################################################################
@@ -320,7 +320,7 @@ class AppCommand(object):
             self.callback()
         except Exception, e:
             current_engine = tank.platform.current_engine()
-            current_engine.log_exception("An exception was raised from Toolkit")
+            current_engine.logger.exception("An exception was raised from Toolkit")
 
     def _find_sub_menu_item(self, menu, label):
         """

--- a/python/tk_maya/panel_generation.py
+++ b/python/tk_maya/panel_generation.py
@@ -84,19 +84,19 @@ def dock_panel(engine, shotgun_panel, title):
         # When the Maya panel already exists, it can be deleted safely since its embedded
         # Shotgun app panel has already been reparented under Maya main window.
         if pm.control(maya_panel_name, query=True, exists=True):
-            engine.log_debug("Deleting existing Maya panel %s." % maya_panel_name)
+            engine.logger.debug("Deleting existing Maya panel %s." % maya_panel_name)
             pm.deleteUI(maya_panel_name)
 
         # Create a new Maya window.
         maya_window = pm.window()
-        engine.log_debug("Created Maya window %s." % maya_window)
+        engine.logger.debug("Created Maya window %s." % maya_window)
 
         # Add a layout to the Maya window.
         maya_layout = pm.formLayout(parent=maya_window)
-        engine.log_debug("Created Maya layout %s." % maya_layout)
+        engine.logger.debug("Created Maya layout %s." % maya_layout)
 
         # Reparent the Shotgun app panel under the Maya window layout.
-        engine.log_debug("Reparenting Shotgun app panel %s under Maya layout %s." % (shotgun_panel_name, maya_layout))
+        engine.logger.debug("Reparenting Shotgun app panel %s under Maya layout %s." % (shotgun_panel_name, maya_layout))
         pm.control(shotgun_panel_name, edit=True, parent=maya_layout)
 
         # Keep the Shotgun app panel sides aligned with the Maya window layout sides.
@@ -109,7 +109,7 @@ def dock_panel(engine, shotgun_panel, title):
         )
 
         # Dock the Maya window into a new tab of Maya Channel Box dock area.
-        engine.log_debug("Creating Maya panel %s." % maya_panel_name)
+        engine.logger.debug("Creating Maya panel %s." % maya_panel_name)
         pm.dockControl(maya_panel_name, area="right", content=maya_window, label=title)
 
         # Since Maya does not give us any hints when a panel is being closed,
@@ -133,7 +133,7 @@ def dock_panel(engine, shotgun_panel, title):
         # displayed for the first time around, or when the user reinvokes a displayed panel.
         if cmds.workspaceControl(maya_panel_name, exists=True):
 
-            engine.log_debug("Restoring Maya workspace panel %s." % maya_panel_name)
+            engine.logger.debug("Restoring Maya workspace panel %s." % maya_panel_name)
 
             # Set the Maya default parent to be our Maya panel workspace control.
             cmds.setParent(maya_panel_name)
@@ -143,14 +143,14 @@ def dock_panel(engine, shotgun_panel, title):
 
             if cmds.control(maya_panel_name, query=True, isObscured=True):
                 # When the panel is not visible, raise it to the top of its workspace area.
-                engine.log_debug("Raising workspace panel %s." % maya_panel_name)
+                engine.logger.debug("Raising workspace panel %s." % maya_panel_name)
                 cmds.workspaceControl(maya_panel_name, edit=True, r=True)
             else:
                 # When the panel is visible, use a workaround to force Maya 2017 to refresh the panel size.
                 # We encased this workaround in a try/except since we cannot be sure
                 # that it will still work without errors in future versions of Maya.
                 try:
-                    engine.log_debug("Forcing Maya to refresh workspace panel %s size." % maya_panel_name)
+                    engine.logger.debug("Forcing Maya to refresh workspace panel %s size." % maya_panel_name)
 
                     # Create a new empty workspace control tab.
                     name = cmds.workspaceControl(uuid.uuid4().hex,
@@ -163,7 +163,7 @@ def dock_panel(engine, shotgun_panel, title):
                     # when deleting the empty workspace control.
                     cmds.workspaceControlState(name, remove=True)
                 except:
-                    engine.log_debug("Cannot force Maya to refresh workspace panel %s size." % maya_panel_name)
+                    engine.logger.debug("Cannot force Maya to refresh workspace panel %s size." % maya_panel_name)
 
             return maya_panel_name
 
@@ -172,7 +172,7 @@ def dock_panel(engine, shotgun_panel, title):
         # It returns an empty string when a dock area cannot be found, but Maya will
         # retrieve the Channel Box dock area even when it is not shown in the current workspace.
         dock_area = mel.eval('getUIComponentDockControl("Channel Box / Layer Editor", false)')
-        engine.log_debug("Retrieved Maya dock area %s." % dock_area)
+        engine.logger.debug("Retrieved Maya dock area %s." % dock_area)
 
         # This UI script will be called to build the UI of the new dock tab.
         # It will embed the Shotgun app panel into a Maya workspace control.
@@ -201,7 +201,7 @@ def dock_panel(engine, shotgun_panel, title):
                     % {"panel_name": shotgun_panel_name}
 
         # Dock the Shotgun app panel into a new workspace control in the active Maya workspace.
-        engine.log_debug("Creating Maya workspace panel %s." % maya_panel_name)
+        engine.logger.debug("Creating Maya workspace panel %s." % maya_panel_name)
 
         kwargs = {"uiScript": ui_script,
                   "retain": False,  # delete the dock tab when it is closed
@@ -256,7 +256,7 @@ def build_workspace_control_ui(shotgun_panel_name):
 
             maya_panel_name = workspace_control.objectName()
 
-            engine.log_debug("Reparenting Shotgun app panel %s under Maya workspace panel %s." % \
+            engine.logger.debug("Reparenting Shotgun app panel %s under Maya workspace panel %s." % \
                              (shotgun_panel_name, maya_panel_name))
 
             # When possible, give a minimum width to the workspace control;
@@ -269,12 +269,12 @@ def build_workspace_control_ui(shotgun_panel_name):
             if size_hint.isValid():
                 # Use the widget recommended width as the workspace control minimum width.
                 minimum_width = size_hint.width()
-                engine.log_debug("Setting Maya workspace panel %s minimum width to %s." % \
+                engine.logger.debug("Setting Maya workspace panel %s minimum width to %s." % \
                                  (maya_panel_name, minimum_width))
                 workspace_control.setMinimumWidth(minimum_width)
             else:
                 # The widget has no recommended size.
-                engine.log_debug("Cannot set Maya workspace panel %s minimum width." % maya_panel_name)
+                engine.logger.debug("Cannot set Maya workspace panel %s minimum width." % maya_panel_name)
 
             # Reparent the Shotgun app panel widget under Maya workspace control.
             widget.setParent(workspace_control)
@@ -285,7 +285,7 @@ def build_workspace_control_ui(shotgun_panel_name):
             # Install an event filter on Maya workspace control to monitor
             # its close event in order to reparent the Shotgun app panel widget
             # under Maya main window for later use.
-            engine.log_debug("Installing a close event filter on Maya workspace panel %s." % maya_panel_name)
+            engine.logger.debug("Installing a close event filter on Maya workspace panel %s." % maya_panel_name)
             panel_util.install_event_filter_by_widget(workspace_control, shotgun_panel_name)
 
             # Delete any leftover workspace control state to avoid a spurious deletion
@@ -293,7 +293,7 @@ def build_workspace_control_ui(shotgun_panel_name):
             if cmds.workspaceControlState(maya_panel_name, exists=True):
                 # Once Maya will have completed its UI update and be idle,
                 # delete the leftover workspace control state.
-                engine.log_debug("Deleting leftover Maya workspace control state %s." % maya_panel_name)
+                engine.logger.debug("Deleting leftover Maya workspace control state %s." % maya_panel_name)
                 maya.utils.executeDeferred(cmds.workspaceControlState, maya_panel_name, remove=True)
 
             break
@@ -315,5 +315,5 @@ def build_workspace_control_ui(shotgun_panel_name):
                 break
         else:
             # The Shotgun app panel that needs to be restored is not in the context configuration.
-            engine.log_error("Cannot restore %s: Shotgun app panel not found. " \
+            engine.logger.error("Cannot restore %s: Shotgun app panel not found. " \
                              "Make sure the app is in the context configuration. "% shotgun_panel_name)

--- a/python/tk_maya/panel_generation.py
+++ b/python/tk_maya/panel_generation.py
@@ -84,19 +84,19 @@ def dock_panel(engine, shotgun_panel, title):
         # When the Maya panel already exists, it can be deleted safely since its embedded
         # Shotgun app panel has already been reparented under Maya main window.
         if pm.control(maya_panel_name, query=True, exists=True):
-            engine.logger.debug("Deleting existing Maya panel %s." % maya_panel_name)
+            engine.logger.debug("Deleting existing Maya panel %s.", maya_panel_name)
             pm.deleteUI(maya_panel_name)
 
         # Create a new Maya window.
         maya_window = pm.window()
-        engine.logger.debug("Created Maya window %s." % maya_window)
+        engine.logger.debug("Created Maya window %s.", maya_window)
 
         # Add a layout to the Maya window.
         maya_layout = pm.formLayout(parent=maya_window)
-        engine.logger.debug("Created Maya layout %s." % maya_layout)
+        engine.logger.debug("Created Maya layout %s.", maya_layout)
 
         # Reparent the Shotgun app panel under the Maya window layout.
-        engine.logger.debug("Reparenting Shotgun app panel %s under Maya layout %s." % (shotgun_panel_name, maya_layout))
+        engine.logger.debug("Reparenting Shotgun app panel %s under Maya layout %s.", shotgun_panel_name, maya_layout)
         pm.control(shotgun_panel_name, edit=True, parent=maya_layout)
 
         # Keep the Shotgun app panel sides aligned with the Maya window layout sides.
@@ -109,7 +109,7 @@ def dock_panel(engine, shotgun_panel, title):
         )
 
         # Dock the Maya window into a new tab of Maya Channel Box dock area.
-        engine.logger.debug("Creating Maya panel %s." % maya_panel_name)
+        engine.logger.debug("Creating Maya panel %s.", maya_panel_name)
         pm.dockControl(maya_panel_name, area="right", content=maya_window, label=title)
 
         # Since Maya does not give us any hints when a panel is being closed,
@@ -133,7 +133,7 @@ def dock_panel(engine, shotgun_panel, title):
         # displayed for the first time around, or when the user reinvokes a displayed panel.
         if cmds.workspaceControl(maya_panel_name, exists=True):
 
-            engine.logger.debug("Restoring Maya workspace panel %s." % maya_panel_name)
+            engine.logger.debug("Restoring Maya workspace panel %s.", maya_panel_name)
 
             # Set the Maya default parent to be our Maya panel workspace control.
             cmds.setParent(maya_panel_name)
@@ -143,14 +143,14 @@ def dock_panel(engine, shotgun_panel, title):
 
             if cmds.control(maya_panel_name, query=True, isObscured=True):
                 # When the panel is not visible, raise it to the top of its workspace area.
-                engine.logger.debug("Raising workspace panel %s." % maya_panel_name)
+                engine.logger.debug("Raising workspace panel %s.", maya_panel_name)
                 cmds.workspaceControl(maya_panel_name, edit=True, r=True)
             else:
                 # When the panel is visible, use a workaround to force Maya 2017 to refresh the panel size.
                 # We encased this workaround in a try/except since we cannot be sure
                 # that it will still work without errors in future versions of Maya.
                 try:
-                    engine.logger.debug("Forcing Maya to refresh workspace panel %s size." % maya_panel_name)
+                    engine.logger.debug("Forcing Maya to refresh workspace panel %s size.", maya_panel_name)
 
                     # Create a new empty workspace control tab.
                     name = cmds.workspaceControl(uuid.uuid4().hex,
@@ -163,7 +163,7 @@ def dock_panel(engine, shotgun_panel, title):
                     # when deleting the empty workspace control.
                     cmds.workspaceControlState(name, remove=True)
                 except:
-                    engine.logger.debug("Cannot force Maya to refresh workspace panel %s size." % maya_panel_name)
+                    engine.logger.debug("Cannot force Maya to refresh workspace panel %s size.", maya_panel_name)
 
             return maya_panel_name
 
@@ -172,7 +172,7 @@ def dock_panel(engine, shotgun_panel, title):
         # It returns an empty string when a dock area cannot be found, but Maya will
         # retrieve the Channel Box dock area even when it is not shown in the current workspace.
         dock_area = mel.eval('getUIComponentDockControl("Channel Box / Layer Editor", false)')
-        engine.logger.debug("Retrieved Maya dock area %s." % dock_area)
+        engine.logger.debug("Retrieved Maya dock area %s.", dock_area)
 
         # This UI script will be called to build the UI of the new dock tab.
         # It will embed the Shotgun app panel into a Maya workspace control.
@@ -201,7 +201,7 @@ def dock_panel(engine, shotgun_panel, title):
                     % {"panel_name": shotgun_panel_name}
 
         # Dock the Shotgun app panel into a new workspace control in the active Maya workspace.
-        engine.logger.debug("Creating Maya workspace panel %s." % maya_panel_name)
+        engine.logger.debug("Creating Maya workspace panel %s.", maya_panel_name)
 
         kwargs = {"uiScript": ui_script,
                   "retain": False,  # delete the dock tab when it is closed
@@ -256,8 +256,8 @@ def build_workspace_control_ui(shotgun_panel_name):
 
             maya_panel_name = workspace_control.objectName()
 
-            engine.logger.debug("Reparenting Shotgun app panel %s under Maya workspace panel %s." % \
-                             (shotgun_panel_name, maya_panel_name))
+            engine.logger.debug("Reparenting Shotgun app panel %s under Maya workspace panel %s.",
+                                shotgun_panel_name, maya_panel_name)
 
             # When possible, give a minimum width to the workspace control;
             # otherwise, it will use the width of the currently displayed tab.
@@ -269,12 +269,12 @@ def build_workspace_control_ui(shotgun_panel_name):
             if size_hint.isValid():
                 # Use the widget recommended width as the workspace control minimum width.
                 minimum_width = size_hint.width()
-                engine.logger.debug("Setting Maya workspace panel %s minimum width to %s." % \
-                                 (maya_panel_name, minimum_width))
+                engine.logger.debug("Setting Maya workspace panel %s minimum width to %s.",
+                                    maya_panel_name, minimum_width)
                 workspace_control.setMinimumWidth(minimum_width)
             else:
                 # The widget has no recommended size.
-                engine.logger.debug("Cannot set Maya workspace panel %s minimum width." % maya_panel_name)
+                engine.logger.debug("Cannot set Maya workspace panel %s minimum width.", maya_panel_name)
 
             # Reparent the Shotgun app panel widget under Maya workspace control.
             widget.setParent(workspace_control)
@@ -285,7 +285,7 @@ def build_workspace_control_ui(shotgun_panel_name):
             # Install an event filter on Maya workspace control to monitor
             # its close event in order to reparent the Shotgun app panel widget
             # under Maya main window for later use.
-            engine.logger.debug("Installing a close event filter on Maya workspace panel %s." % maya_panel_name)
+            engine.logger.debug("Installing a close event filter on Maya workspace panel %s.", maya_panel_name)
             panel_util.install_event_filter_by_widget(workspace_control, shotgun_panel_name)
 
             # Delete any leftover workspace control state to avoid a spurious deletion
@@ -293,7 +293,7 @@ def build_workspace_control_ui(shotgun_panel_name):
             if cmds.workspaceControlState(maya_panel_name, exists=True):
                 # Once Maya will have completed its UI update and be idle,
                 # delete the leftover workspace control state.
-                engine.logger.debug("Deleting leftover Maya workspace control state %s." % maya_panel_name)
+                engine.logger.debug("Deleting leftover Maya workspace control state %s.", maya_panel_name)
                 maya.utils.executeDeferred(cmds.workspaceControlState, maya_panel_name, remove=True)
 
             break
@@ -316,4 +316,4 @@ def build_workspace_control_ui(shotgun_panel_name):
         else:
             # The Shotgun app panel that needs to be restored is not in the context configuration.
             engine.logger.error("Cannot restore %s: Shotgun app panel not found. " \
-                             "Make sure the app is in the context configuration. "% shotgun_panel_name)
+                             "Make sure the app is in the context configuration. ", shotgun_panel_name)


### PR DESCRIPTION
Remove legacy log_* methods and use engine.logger.* instead.

These changes are for task: http://internal.shotgunstudio.int/page/10287#Ticket_41526_%5Btk-maya%5D%3A%20Finish%20switching%20to%20new%20style%20logging%20in%20the%20engine.