### PR TITLE
41524 Only adding logout menu if running shotguns maya plugin as stan…

### DIFF
--- a/plugins/basic/python/tk_maya_basic/plugin_logic.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logic.py
@@ -148,12 +148,14 @@ def _handle_bootstrap_completed(engine):
     # Report completion of the bootstrap.
     standalone_logger.info("Integration loaded.")
 
-    # Add a logout menu item to the engine context menu.
-    sgtk.platform.current_engine().register_command(
-        "Log Out of Shotgun",
-        _logout_user,
-        {"type": "context_menu"}
-    )
+    # Add a logout menu item to the engine context menu, but only if
+    # running as a standalone plugin
+    if sgtk.platform.current_engine().context.project is None:
+        sgtk.platform.current_engine().register_command(
+            "Log Out of Shotgun",
+            _logout_user,
+            {"type": "context_menu"}
+        )
 
 
 def _handle_bootstrap_failed(phase, exception):


### PR DESCRIPTION
Only adding the logout menu when running the plugin standalone. When running from a desktop launch (with an associated project in the context) the menu option will not be available

Built and tested running standalone with this command

`D:\projects\shotgun\manual\tk-core\developer>python build_plugin.py --bootstrap-core-uri=sgtk:descriptor:dev?path=D:\projects\shotgun\manual\tk-core \projects\shotgun\manual\tk-maya\plugins\basic \luis\maya 
`

In the case above the menu item will show up.

Then, tested launching Maya from the Shotgun Desktop launcher with Zero Config setup from the 'luis_test_dev' project in zero-config-demo.shotgunstudio.com; the menu item is NOT visible/available

