### PR TITLE
41524 Fix to old versions of toolkit standalone plugins being loaded …

### DIFF
--- a/startup.py
+++ b/startup.py
@@ -109,7 +109,10 @@ class MayaLauncher(SoftwareLauncher):
                     self.logger.debug("Preparing to launch builtin plugin '%s'" % load_plugin)
                     load_maya_plugins.append(load_plugin)
                     if load_plugin not in maya_module_paths:
-                        maya_module_paths.append(load_plugin)
+                        # Insert at begining of list to give priority to toolkit plugins
+                        # launched from the desktop app over standalone ones whose
+                        # path is already part of the MAYA_MODULE_PATH env var
+                        maya_module_paths.insert(0, load_plugin)
                 else:
                     # Report the missing plugin directory
                     self.logger.warning(

--- a/startup.py
+++ b/startup.py
@@ -109,7 +109,7 @@ class MayaLauncher(SoftwareLauncher):
                     self.logger.debug("Preparing to launch builtin plugin '%s'" % load_plugin)
                     load_maya_plugins.append(load_plugin)
                     if load_plugin not in maya_module_paths:
-                        # Insert at begining of list to give priority to toolkit plugins
+                        # Insert at beginning of list to give priority to toolkit plugins
                         # launched from the desktop app over standalone ones whose
                         # path is already part of the MAYA_MODULE_PATH env var
                         maya_module_paths.insert(0, load_plugin)


### PR DESCRIPTION
…instead of toolkit desktop ones. The loading priority is now reversed, desktop app toolkit plugins have priority over standalone ones

These changes improve the changes in https://github.com/shotgunsoftware/tk-maya/pull/49 by fixing issue noted by @mathurf 