### PR TITLE
fix multiple shotgun disabled menu

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -187,6 +187,7 @@ def create_sgtk_disabled_menu(menu_name):
     if pm.menu("ShotgunMenu", exists=True):
         pm.deleteUI("ShotgunMenu")
 
+    remove_sgtk_disabled_menu()
     sg_menu = pm.menu("ShotgunMenuDisabled", label=menu_name, parent=pm.melGlobals["gMainWindow"])
     pm.menuItem(label="Sgtk is disabled.", parent=sg_menu,
                 command=lambda arg: sgtk_disabled_message())


### PR DESCRIPTION
When refresh_engine() is called, if no tank instance was able to be initialized from the path, the shotgun disabled menu is created. However there's no check to delete it if it already existed. 

Reprosteps:
- Initialize tk-maya
- Open a scene that don't match the schema
- Notice there's one Shotgun "disabled" menu
- Open another scene that don't match the schema
- Notice there's two Shotgun "disabled" menu