### PR TITLE
For #44161: Maya 2018 Windows compatibility.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -261,8 +261,18 @@ class MayaEngine(tank.platform.Engine):
         maya_ver = cmds.about(version=True)
         if maya_ver.startswith("Maya "):
             maya_ver = maya_ver[5:]
-        if maya_ver.startswith(("2014", "2015", "2016", "2017")):
+        if maya_ver.startswith(("2014", "2015", "2016", "2017", "2018")):
             self.logger.debug("Running Maya version %s", maya_ver)
+
+            # In the case of Maya 2018 on Windows, we have the possility of locking
+            # up if we allow the PySide shim to import QtWebEngineWidgets. We can
+            # stop that happening here by setting the environment variable.
+            if maya_ver.startswith("2018") and current_os.startswith("win"):
+                self.logger.debug(
+                    "Maya 2018 on Windows can deadlock if QtWebEngineWidgets "
+                    "is imported. Setting SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT=1..."
+                )
+                os.environ["SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT"] = 1
         elif maya_ver.startswith(("2012", "2013")):
             # We won't be able to rely on the warning dialog below, because Maya
             # older than 2014 doesn't ship with PySide. Instead, we just have to

--- a/engine.py
+++ b/engine.py
@@ -272,7 +272,7 @@ class MayaEngine(tank.platform.Engine):
                     "Maya 2018 on Windows can deadlock if QtWebEngineWidgets "
                     "is imported. Setting SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT=1..."
                 )
-                os.environ["SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT"] = 1
+                os.environ["SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT"] = "1"
         elif maya_ver.startswith(("2012", "2013")):
             # We won't be able to rely on the warning dialog below, because Maya
             # older than 2014 doesn't ship with PySide. Instead, we just have to

--- a/engine.py
+++ b/engine.py
@@ -267,9 +267,11 @@ class MayaEngine(tank.platform.Engine):
             # In the case of Maya 2018 on Windows, we have the possility of locking
             # up if we allow the PySide shim to import QtWebEngineWidgets. We can
             # stop that happening here by setting the environment variable.
-            if maya_ver.startswith("2018") and current_os.startswith("win"):
+            version_num = int(maya_ver[0:4])
+
+            if version_num >= 2018 and current_os.startswith("win"):
                 self.logger.debug(
-                    "Maya 2018 on Windows can deadlock if QtWebEngineWidgets "
+                    "Maya 2018+ on Windows can deadlock if QtWebEngineWidgets "
                     "is imported. Setting SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT=1..."
                 )
                 os.environ["SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT"] = "1"


### PR DESCRIPTION
We have an issue where it is possible to deadlock Maya on import of QtWebEngineWidgets. If we know we are in 2018 on Windows, we set an environment variable that tells tk-core to not import that submodule.