### PR TITLE
Ensure automatic_context_switch works when switching environments

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -435,7 +435,11 @@ class MayaEngine(Engine):
             # that has a callback registered with the new context baked in.
             # This will ensure that the context_from_path call that occurs
             # after a File->Open receives an up-to-date "previous" context.
-            self.__watcher.stop_watching()
+            
+            # If we switch from an env where this is False to one that is 
+            # True, we won't have a watcher instance, so we check for it first.
+            if hasattr(self, "__watcher"):
+                self.__watcher.stop_watching()
             cb_fn = lambda en=self.instance_name, pc=new_context, mn=self._menu_name:on_scene_event_callback(
                 engine_name=en,
                 prev_context=pc,


### PR DESCRIPTION
When you switch from an environment where `automatic_context_switch=False` to one where `automatic_context_switch=True`, this fix ensures that there's a `__watcher` instance currently registered with the engine before trying to call `stop_watching()`

Previously this would throw an error. In this case launching Maya from SG Desktop into the project environment where `automatic_context_switch=False`. Then using the File Manager, opening an asset which attempted to bring me into the asset_step environment where `automatic_context_switch=True`:
```
// Error: Shotgun tk-multi-workfiles2: Failed to change the work area to lookdev, Asset juggernaut!
Traceback (most recent call last):
File "/Users/kp/Library/Caches/Shotgun/bundle_cache/app_store/tk-multi-workfiles2/v0.10.0/python/tk_multi_workfiles/actions/open_file_action.py", line 115, in _do_copy_and_open
FileAction.change_context(new_ctx)
File "/Users/kp/Library/Caches/Shotgun/bundle_cache/app_store/tk-multi-workfiles2/v0.10.0/python/tk_multi_workfiles/actions/file_action.py", line 123, in change_context
raise TankError("Failed to change work area - %s" % e)
TankError: Failed to change work area - 'MayaEngine' object has no attribute '_MayaEngine__watcher' //
```