### PR TITLE
SG-9012: Ensures that progress updates are always run in the main thread during bootstrap.

### DIFF
--- a/plugins/basic/python/tk_maya_basic/plugin_logic.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logic.py
@@ -173,7 +173,7 @@ def _handle_bootstrap_completed(engine):
 
     :param engine: Launched :class:`sgtk.platform.Engine` instance.
     """
-    PROGRESS_HANDLER.timer.stop()
+    progress_handler.timer.stop()
 
     # Needed global to re-import the toolkit core.
     global sgtk
@@ -207,7 +207,7 @@ def _handle_bootstrap_failed(phase, exception):
                   ``ToolkitManager.TOOLKIT_BOOTSTRAP_PHASE`` or ``ToolkitManager.ENGINE_STARTUP_PHASE``.
     :param exception: Python exception raised while bootstrapping.
     """
-    PROGRESS_HANDLER.timer.stop()
+    progress_handler.timer.stop()
 
     # Needed global to re-import the toolkit core.
     global sgtk

--- a/plugins/basic/python/tk_maya_basic/plugin_logic.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logic.py
@@ -13,6 +13,7 @@ import logging
 import maya.utils
 import pymel.core as pm
 import maya.OpenMaya as OpenMaya
+import maya.OpenMayaUI as OpenMayaUI
 
 # For now, import the Shotgun toolkit core included with the plug-in,
 # but also re-import it later to ensure usage of a swapped in version.
@@ -32,6 +33,68 @@ MENU_LOGIN = "ShotgunMenuLogin"
 MENU_LABEL = "Shotgun"
 
 logger = sgtk.LogManager.get_logger(__name__)
+
+class ProgressHandler(QtCore.QObject):
+    """
+    An object that wraps a QTimer that is used to periodically check
+    for updates that need to be made to the progress bar in Maya. This
+    will always execute progress updates on the main thread.
+    """
+    PROGRESS_INTERVAL = 150 # milliseconds
+
+    def __init__(self):
+        try:
+            import shiboken2 as shiboken
+        except ImportError:
+            import shiboken
+
+        ptr = OpenMayaUI.MQtUtil.mainWindow()
+        parent = shiboken.wrapInstance(long(ptr), QtGui.QMainWindow)
+
+        super(ProgressHandler, self).__init__(parent=parent)
+
+        self._progress_value = None
+        self._message = None
+        self._timer = QtCore.QTimer(parent=self)
+
+        self._timer.timeout.connect(self._set_progress)
+        self._timer.start(self.PROGRESS_INTERVAL)
+
+    @property
+    def timer(self):
+        """
+        The QTimer instance that's updating progress.
+        """
+        return self._timer
+
+    def _set_progress(self):
+        """
+        Sets progress. Must be run from the main thread!
+        """
+        if self._message and self._progress_value:
+            _show_progress_bar(self._progress_value, self._message)
+            self._message = None
+            self._progress_value = None
+
+    def _handle_bootstrap_progress(self, progress_value, message):
+        """
+        Callback function that reports back on the toolkit and engine bootstrap progress.
+
+        This function is executed in the main thread by the main event loop.
+
+        :param progress_value: Current progress value, ranging from 0.0 to 1.0.
+        :param message: Progress message to report.
+        """
+
+        logger.debug("Bootstrapping Shotgun: %s" % message)
+
+        # Show the progress bar, and update its value and message.
+        # _show_progress_bar(progress_value, message)
+        self._progress_value = progress_value
+        self._message = message
+
+
+PROGRESS_HANDLER = ProgressHandler()
 
 
 def bootstrap():
@@ -91,7 +154,7 @@ def _login_user():
     try:
         plugin_engine.bootstrap(
             user,
-            progress_callback=_handle_bootstrap_progress,
+            progress_callback=PROGRESS_HANDLER._handle_bootstrap_progress,
             completed_callback=_handle_bootstrap_completed,
             failed_callback=_handle_bootstrap_failed
         )
@@ -102,22 +165,6 @@ def _login_user():
         logger.exception("Shotgun reported the following exception during startup:")
 
 
-def _handle_bootstrap_progress(progress_value, message):
-    """
-    Callback function that reports back on the toolkit and engine bootstrap progress.
-
-    This function is executed in the main thread by the main event loop.
-
-    :param progress_value: Current progress value, ranging from 0.0 to 1.0.
-    :param message: Progress message to report.
-    """
-
-    logger.debug("Bootstrapping Shotgun: %s" % message)
-
-    # Show the progress bar, and update its value and message.
-    _show_progress_bar(progress_value, message)
-
-
 def _handle_bootstrap_completed(engine):
     """
     Callback function that handles cleanup after successful completion of the bootstrap.
@@ -126,6 +173,7 @@ def _handle_bootstrap_completed(engine):
 
     :param engine: Launched :class:`sgtk.platform.Engine` instance.
     """
+    PROGRESS_HANDLER.timer.stop()
 
     # Needed global to re-import the toolkit core.
     global sgtk
@@ -159,6 +207,7 @@ def _handle_bootstrap_failed(phase, exception):
                   ``ToolkitManager.TOOLKIT_BOOTSTRAP_PHASE`` or ``ToolkitManager.ENGINE_STARTUP_PHASE``.
     :param exception: Python exception raised while bootstrapping.
     """
+    PROGRESS_HANDLER.timer.stop()
 
     # Needed global to re-import the toolkit core.
     global sgtk


### PR DESCRIPTION
Updating Maya's progress bar is NOT thread safe, so we need to ensure that all updates of progress there are processed in the main thread. The callback function registered with the bootstrapper is now only responsible for setting state on an object, and a QTimer running on the main thread updates the progress bar when necessary. This addresses a freeze/crash bug on launch of Maya when tk-core v0.18.153 is in use.