### PR TITLE
SG-10146: Fix for window parenting on OS X.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -580,13 +580,22 @@ class MayaEngine(Engine):
 
     def _create_dialog(self, *args, **kwargs):
         """
+        Overrides the base behavior of _create_dialog on OS X to set an additional property
+        on the created dialog to resolve window parenting issues. On Windows or Linux, the
+        base implementation is used unaltered.
 
+        :returns: The newly-created dialog.
         """
-        # TODO: only OSX
-        # TODO: get an explanation and document why we're having to do this
-        w = super(MayaEngine, self)._create_dialog(*args, **kwargs)
-        w.setProperty("saveWindowPref", True )
-        return w
+        dialog = super(MayaEngine, self)._create_dialog(*args, **kwargs)
+
+        # TODO: Get an explanation and document why we're having to do this. It appears to be
+        # a Maya-only solution, because similar problems in other integrations, namely Nuke,
+        # are not resolved in the same way. This fix comes to us from the Maya dev team, but
+        # we've not yet spoken with someone that can explain why it fixes the problem.
+        if sys.platform == "darwin":
+            dialog.setProperty("saveWindowPref", True )
+
+        return dialog
 
     def _get_dialog_parent(self):
         """

--- a/engine.py
+++ b/engine.py
@@ -578,6 +578,16 @@ class MayaEngine(Engine):
             self.logger.error("PySide could not be imported! Apps using pyside will not "
                            "operate correctly! Error reported: %s", e)
 
+    def _create_dialog(self, *args, **kwargs):
+        """
+
+        """
+        # TODO: only OSX
+        # TODO: get an explanation and document why we're having to do this
+        w = super(MayaEngine, self)._create_dialog(*args, **kwargs)
+        w.setProperty("saveWindowPref", True )
+        return w
+
     def _get_dialog_parent(self):
         """
         Get the QWidget parent for all dialogs created through


### PR DESCRIPTION
This resolves a long-standing problem with Qt window parenting in Maya on OS X. Dialogs will no longer fall behind Maya when they lose focus.

This fix is simple, but very opaque. It comes to us from the Maya dev team, but the people we've spoken to so far do not have an explanation for why it's required. This is the same solution they use for their own Python-based dialogs, so it should be safe.