### PR TITLE
SG-14316 Fixes exporting alembic file paths with spaces

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_session_geometry.py
+++ b/hooks/tk-multi-publish2/basic/publish_session_geometry.py
@@ -273,7 +273,7 @@ class MayaSessionGeometryPublishPlugin(HookBaseClass):
 
         # Set the output path: 
         # Note: The AbcExport command expects forward slashes!
-        alembic_args.append("-file %s" % publish_path.replace("\\", "/"))
+        alembic_args.append("-file '%s'" % publish_path.replace("\\", "/"))
 
         # build the export command.  Note, use AbcExport -help in Maya for
         # more detailed Alembic export help


### PR DESCRIPTION
Fixes a bug with exporting alembic files if there was a space somewhere in the path.
Previously if you had a path like `"c:\my folder\my_file.abc"` then it would error saying unsupported flags: `folder\my_file.abc` and `Can 't write to file: c:\my`.

This fix encapsulates the file path in a single quote string.