### PR TITLE
SG-15270 Fixed a Workfiles2 error in Maya 2020

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -630,7 +630,7 @@ class MayaEngine(Engine):
             # the dialog's size before Maya gets ahold of it, and then resize it
             # right after it's shown. We'll also move the dialog to the center of
             # the desktop.
-            center_screen = QtGui.QApplication.instance().desktop().availableGeometry(dialog).center()
+            center_screen = QtGui.QApplication.desktop().availableGeometry(dialog).center()
             self.__DIALOG_SIZE_CACHE[title] = dialog.size()
 
             # TODO: Get an explanation and document why we're having to do this. It appears to be


### PR DESCRIPTION
Fixed an error we were getting in the script editor after launching Maya 2020. It prevented Workfiles2 to auto launch on startup.