### PR TITLE
SG-29238 Prevent AttributeError when path is missing

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -347,7 +347,7 @@ class MayaSessionPublishPlugin(HookBaseClass):
         super(MayaSessionPublishPlugin, self).finalize(settings, item)
 
         # bump the session file to the next version
-        self._save_to_next_version(item.properties["path"], item, _save_session)
+        self._save_to_next_version(item.get_property("path"), item, _save_session)
 
 
 def _maya_find_additional_session_dependencies():

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -346,11 +346,6 @@ class MayaSessionPublishPlugin(HookBaseClass):
         # do the base class finalization
         super(MayaSessionPublishPlugin, self).finalize(settings, item)
 
-        # TODO:Remove me after QA
-        self.logger.info(
-            "Finalized (tk-maya): %s" % (item.get_property("path"),),
-            extra={"action_show_folder": {"path": item.get_property("path")}},
-        )
         self._save_to_next_version(item.get_property("path"), item, _save_session)
 
 

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -346,7 +346,11 @@ class MayaSessionPublishPlugin(HookBaseClass):
         # do the base class finalization
         super(MayaSessionPublishPlugin, self).finalize(settings, item)
 
-        # bump the session file to the next version
+        # TODO:Remove me after QA
+        self.logger.info(
+            "Finalized (tk-maya): %s" % (item.get_property("path"),),
+            extra={"action_show_folder": {"path": item.get_property("path")}},
+        )
         self._save_to_next_version(item.get_property("path"), item, _save_session)
 
 


### PR DESCRIPTION
- There are cases on custom plugins when `path` is stored under `local_properties`. This update prevent the publish plugin from breaking on `finalize` step.
- Needs https://github.com/shotgunsoftware/tk-multi-publish2/pull/168