### PR TITLE
SG-33412 Error while saving a work file in maya.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -859,7 +859,16 @@ class MayaEngine(Engine):
 
         # Since we are inserting this path into another string that will be executed in mel
         # We need to double up and backslashes.
-        proj_path = proj_path.replace("\\", "\\\\")
+        # For network paths (starting with '\\\\'), doubling backslashes is avoided
+        # as this leads to RuntimeErrors when executed in mel.
+        if not proj_path.startswith('\\\\'):
+            # Local path and requires escaping
+            proj_path = proj_path.replace("\\", "\\\\")
+        try:
+            cmds.workspace(proj_path, openWorkspace=True)
+        except RuntimeError as e:
+            self.logger.error('Maya failed to open Project. Error: %s', str(e))
+            raise e
 
         cmds.workspace(proj_path, openWorkspace=True)
 

--- a/engine.py
+++ b/engine.py
@@ -861,10 +861,9 @@ class MayaEngine(Engine):
 
         # Since we are inserting this path into another string that will be executed in mel
         # We need to double up and backslashes.
-        # For network paths (starting with '\\\\'), doubling backslashes is avoided
+        # For network paths on Windows (starting with '\\\\'), doubling backslashes is avoided
         # as this leads to RuntimeErrors when executed in mel.
         if not (sgtk.util.is_windows() and proj_path.startswith("\\\\")):
-            # Local path and requires escaping
             proj_path = proj_path.replace("\\", "\\\\")
         try:
             cmds.workspace(proj_path, openWorkspace=True)

--- a/engine.py
+++ b/engine.py
@@ -844,6 +844,8 @@ class MayaEngine(Engine):
     ##########################################################################################
     # scene and project management
 
+
+
     def _set_project(self):
         """
         Set the maya project
@@ -861,7 +863,7 @@ class MayaEngine(Engine):
         # We need to double up and backslashes.
         # For network paths (starting with '\\\\'), doubling backslashes is avoided
         # as this leads to RuntimeErrors when executed in mel.
-        if not proj_path.startswith("\\\\"):
+        if not (sgtk.util.is_windows() and proj_path.startswith("\\\\")):
             # Local path and requires escaping
             proj_path = proj_path.replace("\\", "\\\\")
         try:

--- a/engine.py
+++ b/engine.py
@@ -844,8 +844,6 @@ class MayaEngine(Engine):
     ##########################################################################################
     # scene and project management
 
-
-
     def _set_project(self):
         """
         Set the maya project

--- a/engine.py
+++ b/engine.py
@@ -861,13 +861,13 @@ class MayaEngine(Engine):
         # We need to double up and backslashes.
         # For network paths (starting with '\\\\'), doubling backslashes is avoided
         # as this leads to RuntimeErrors when executed in mel.
-        if not proj_path.startswith('\\\\'):
+        if not proj_path.startswith("\\\\"):
             # Local path and requires escaping
             proj_path = proj_path.replace("\\", "\\\\")
         try:
             cmds.workspace(proj_path, openWorkspace=True)
         except RuntimeError as e:
-            self.logger.error('Maya failed to open Project. Error: %s', str(e))
+            self.logger.error("Maya failed to open Project. Error: %s", str(e))
             raise e
 
         cmds.workspace(proj_path, openWorkspace=True)

--- a/engine.py
+++ b/engine.py
@@ -857,12 +857,6 @@ class MayaEngine(Engine):
         proj_path = tmpl.apply_fields(fields)
         self.logger.info("Setting Maya project to '%s'", proj_path)
 
-        # Since we are inserting this path into another string that will be executed in mel
-        # We need to double up and backslashes.
-        # For network paths on Windows (starting with '\\\\'), doubling backslashes is avoided
-        # as this leads to RuntimeErrors when executed in mel.
-        if not (sgtk.util.is_windows() and proj_path.startswith("\\\\")):
-            proj_path = proj_path.replace("\\", "\\\\")
         try:
             cmds.workspace(proj_path, openWorkspace=True)
         except RuntimeError as e:


### PR DESCRIPTION
This PR fixes the `RuntimeError` happening where network paths on Windows were double-escaped in `_set_project` and executed in cmds.workspace.