### PR TITLE
SG-31832 Add support for PySide6 and update shiboken bindings in Maya engine.

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -793,17 +793,8 @@ class MayaEngine(Engine):
         show_dialog & show_modal.
         """
         # Find a parent for the dialog - this is the Maya mainWindow()
-        from sgtk.platform.qt import QtGui
+        from sgtk.platform.qt import QtGui, shiboken
         import maya.OpenMayaUI as OpenMayaUI
-
-        # Try importing PySide6 modules first
-        try:
-            import shiboken6 as shiboken
-        except ImportError:
-            try:
-                import shiboken2 as shiboken
-            except ImportError:
-                import shiboken
 
         ptr = OpenMayaUI.MQtUtil.mainWindow()
         parent = shiboken.wrapInstance(int(ptr), QtGui.QMainWindow)

--- a/engine.py
+++ b/engine.py
@@ -395,6 +395,7 @@ class MayaEngine(Engine):
                 "2022",
                 "2023",
                 "2024",
+                "2025",
             )
         ):
             self.logger.debug("Running Maya version %s", maya_ver)

--- a/engine.py
+++ b/engine.py
@@ -654,7 +654,18 @@ class MayaEngine(Engine):
         Handles the pyside init
         """
 
-        # first see if pyside2 is present
+        # First see if pyside6 is present
+        try:
+            from PySide6 import QtGui
+        except:
+            # fine, we don't expect PySide2 to be present just yet
+            self.logger.debug("PySide6 not detected - trying for PySide2 now...")
+        else:
+            # looks like pyside2 is already working! No need to do anything
+            self.logger.debug("PySide6 detected - the existing version will be used.")
+            return
+
+        # Next, check if PySide2 is present
         try:
             from PySide2 import QtGui
         except:
@@ -665,7 +676,7 @@ class MayaEngine(Engine):
             self.logger.debug("PySide2 detected - the existing version will be used.")
             return
 
-        # then see if pyside is present
+        # Then see if pyside is present
         try:
             from PySide import QtGui
         except:
@@ -784,10 +795,14 @@ class MayaEngine(Engine):
         from sgtk.platform.qt import QtGui
         import maya.OpenMayaUI as OpenMayaUI
 
+        # Try importing PySide6 modules first
         try:
-            import shiboken2 as shiboken
+            import shiboken6 as shiboken
         except ImportError:
-            import shiboken
+            try:
+                import shiboken2 as shiboken
+            except ImportError:
+                import shiboken
 
         ptr = OpenMayaUI.MQtUtil.mainWindow()
         parent = shiboken.wrapInstance(int(ptr), QtGui.QMainWindow)

--- a/info.yml
+++ b/info.yml
@@ -93,4 +93,4 @@ description: "ShotGrid Integration in Maya"
 
 # Required minimum versions for this item to run
 requires_shotgun_version:
-requires_core_version: "v0.20.5"
+requires_core_version: "v0.21.1"

--- a/plugins/basic/python/tk_maya_basic/plugin_logic.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logic.py
@@ -17,9 +17,14 @@ import maya.mel as mel
 import maya.cmds as cmds
 
 try:
-    import shiboken2 as shiboken
+    import shiboken6 as shiboken
 except ImportError:
-    import shiboken
+    try:
+        import shiboken2 as shiboken
+    except ImportError:
+        # If shiboken6 or shiboken2 are not available,
+        # fall back to shiboken for PySide
+        import shiboken
 
 # For now, import the Shotgun toolkit core included with the plug-in,
 # but also re-import it later to ensure usage of a swapped in version.

--- a/plugins/basic/python/tk_maya_basic/plugin_logic.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logic.py
@@ -16,19 +16,10 @@ import maya.OpenMayaUI as OpenMayaUI
 import maya.mel as mel
 import maya.cmds as cmds
 
-try:
-    import shiboken6 as shiboken
-except ImportError:
-    try:
-        import shiboken2 as shiboken
-    except ImportError:
-        # If shiboken6 or shiboken2 are not available,
-        # fall back to shiboken for PySide
-        import shiboken
-
 # For now, import the Shotgun toolkit core included with the plug-in,
 # but also re-import it later to ensure usage of a swapped in version.
 import sgtk
+from sgtk.platform.qt import shiboken
 
 # Knowing that the plug-in is only loaded for Maya 2014 and later,
 # import PySide packages without having to worry about the version to use

--- a/plugins/basic/python/tk_maya_basic/plugin_logic.py
+++ b/plugins/basic/python/tk_maya_basic/plugin_logic.py
@@ -19,7 +19,6 @@ import maya.cmds as cmds
 # For now, import the Shotgun toolkit core included with the plug-in,
 # but also re-import it later to ensure usage of a swapped in version.
 import sgtk
-from sgtk.platform.qt import shiboken
 
 # Knowing that the plug-in is only loaded for Maya 2014 and later,
 # import PySide packages without having to worry about the version to use
@@ -29,6 +28,7 @@ from sgtk.util.qt_importer import QtImporter
 qt_importer = QtImporter()
 QtCore = qt_importer.QtCore
 QtGui = qt_importer.QtGui
+shiboken = qt_importer.shiboken
 
 from . import plugin_engine
 

--- a/python/tk_maya/panel_generation.py
+++ b/python/tk_maya/panel_generation.py
@@ -269,21 +269,17 @@ def build_workspace_control_ui(shotgun_panel_name):
 
     # In the context of this function, we know that we are running in Maya 2017 and later
     # with the newer versions of PySide and shiboken.
-    # Try importing PySide6 modules first
-    try:
-        from PySide6 import QtWidgets
-    except ImportError:
-        from PySide2 import QtWidgets
+    from sgtk.platform.qt import QtGui
 
     # Retrieve the Maya engine.
     engine = sgtk.platform.current_engine()
 
     # Retrieve the calling Maya workspace control.
     ptr = MQtUtil.getCurrentParent()
-    workspace_control = shiboken.wrapInstance(int(ptr), QtWidgets.QWidget)
+    workspace_control = shiboken.wrapInstance(int(ptr), QtGui.QWidget)
 
     # Search for the Shotgun app panel widget.
-    for widget in QtWidgets.QApplication.allWidgets():
+    for widget in QtGui.QApplication.allWidgets():
         if widget.objectName() == shotgun_panel_name:
 
             maya_panel_name = workspace_control.objectName()

--- a/python/tk_maya/panel_generation.py
+++ b/python/tk_maya/panel_generation.py
@@ -264,18 +264,16 @@ def build_workspace_control_ui(shotgun_panel_name):
     """
 
     from maya.OpenMayaUI import MQtUtil
+    import sgtk.platform
+    from sgtk.platform.qt import shiboken
 
     # In the context of this function, we know that we are running in Maya 2017 and later
     # with the newer versions of PySide and shiboken.
     # Try importing PySide6 modules first
     try:
         from PySide6 import QtWidgets
-        import shiboken6 as shiboken
     except ImportError:
         from PySide2 import QtWidgets
-        import shiboken2 as shiboken
-
-    import sgtk.platform
 
     # Retrieve the Maya engine.
     engine = sgtk.platform.current_engine()

--- a/python/tk_maya/panel_generation.py
+++ b/python/tk_maya/panel_generation.py
@@ -267,8 +267,13 @@ def build_workspace_control_ui(shotgun_panel_name):
 
     # In the context of this function, we know that we are running in Maya 2017 and later
     # with the newer versions of PySide and shiboken.
-    from PySide2 import QtWidgets
-    from shiboken2 import wrapInstance
+    # Try importing PySide6 modules first
+    try:
+        from PySide6 import QtWidgets
+        import shiboken6 as shiboken
+    except ImportError:
+        from PySide2 import QtWidgets
+        import shiboken2 as shiboken
 
     import sgtk.platform
 
@@ -277,7 +282,7 @@ def build_workspace_control_ui(shotgun_panel_name):
 
     # Retrieve the calling Maya workspace control.
     ptr = MQtUtil.getCurrentParent()
-    workspace_control = wrapInstance(int(ptr), QtWidgets.QWidget)
+    workspace_control = shiboken.wrapInstance(int(ptr), QtWidgets.QWidget)
 
     # Search for the Shotgun app panel widget.
     for widget in QtWidgets.QApplication.allWidgets():

--- a/python/tk_maya/panel_util.py
+++ b/python/tk_maya/panel_util.py
@@ -15,17 +15,7 @@ Panel support utilities for Maya
 import maya.mel as mel
 import maya.OpenMayaUI as OpenMayaUI
 
-from sgtk.platform.qt import QtCore, QtGui
-
-try:
-    import shiboken6 as shiboken
-except ImportError:
-    try:
-        import shiboken2 as shiboken
-    except ImportError:
-        # If shiboken6 or shiboken2 are not available,
-        # fall back to shiboken for PySide
-        import shiboken
+from sgtk.platform.qt import QtCore, QtGui, shiboken
 
 
 def install_event_filter_by_name(maya_panel_name, shotgun_panel_name):

--- a/python/tk_maya/panel_util.py
+++ b/python/tk_maya/panel_util.py
@@ -18,9 +18,14 @@ import maya.OpenMayaUI as OpenMayaUI
 from sgtk.platform.qt import QtCore, QtGui
 
 try:
-    import shiboken2 as shiboken
+    import shiboken6 as shiboken
 except ImportError:
-    import shiboken
+    try:
+        import shiboken2 as shiboken
+    except ImportError:
+        # If shiboken6 or shiboken2 are not available,
+        # fall back to shiboken for PySide
+        import shiboken
 
 
 def install_event_filter_by_name(maya_panel_name, shotgun_panel_name):


### PR DESCRIPTION
This continues with the work done on [SG-31832-poc ](https://github.com/shotgunsoftware/tk-maya/tree/SG-31832-poc),  introduces compatibility with PySide6 for the Maya engine. It includes updating the import statements and the shiboken bindings to maintain functionality across different supported PySide versions.

Requires the changes made in tk-core [here](https://github.com/shotgunsoftware/tk-maya/pull/106). 
It is necessary to increase the minimum version of tk-core `requires_core_version` in the info.yml.
