### PR TITLE
PIPEDEV-110   move Maya engine from config into a separate repo

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -177,11 +177,19 @@ def refresh_engine(engine_name, prev_context, menu_name):
         logger.debug("Extracted sgtk instance: '%r' from path: '%r'", tk, new_path)
 
     except sgtk.TankError as e:
-        logger.exception("Could not execute sgtk_from_path('%s')" % new_path)
-        OpenMaya.MGlobal.displayInfo("ShotGrid: Engine cannot be started: %s" % e)
-        # build disabled menu
-        create_sgtk_disabled_menu(menu_name)
-        return
+        if prev_context.project:
+            logger.warn('Falling back to project context `{prev_context}` ' \
+                        'because the scene file path is unknown.'.format(prev_context=prev_context))
+            tk = sgtk.sgtk_from_entity('Project', prev_context.project['id'])
+            ctx = tk.context_from_entity('Project', prev_context.project['id'])
+            current_engine.change_context(ctx)
+            return
+        else:
+            logger.exception("Could not execute sgtk_from_path('%s')" % new_path)
+            OpenMaya.MGlobal.displayInfo("ShotGrid: Engine cannot be started: %s" % e)
+            # build disabled menu
+            create_sgtk_disabled_menu(menu_name)
+            return
 
     # shotgun menu may have been removed, so add it back in if its not already there.
     current_engine.create_shotgun_menu()

--- a/python/tk_maya/menu_generation.py
+++ b/python/tk_maya/menu_generation.py
@@ -248,7 +248,24 @@ class AppCommand(Callback):
         self.name = name
         self.properties = command_dict["properties"]
         self.favourite = False
-        super(AppCommand, self).__init__(command_dict["callback"])
+        self._callback = command_dict["callback"]
+
+        super(AppCommand, self).__init__(self._show_existing_window_or_run_callback)
+
+
+    def _show_existing_window_or_run_callback(self, *a, **kwa):
+        display_name = 'ShotGrid: ' + self.name.rstrip(' .')
+        tops = QtGui.QApplication.topLevelWidgets()
+        for top in tops:
+            if top.isWindow() and \
+               display_name in top.windowTitle() and \
+               top.__class__.__name__ == 'TankQDialog':
+                top.show()
+                top.activateWindow()
+                return None
+
+        return self._callback(*a, **kwa)
+
 
     def get_app_name(self):
         """


### PR DESCRIPTION
Implement fallback to project context and adjust menu callbacks

Updated the exception handling in tk-maya/engine.py to allow for a fallback to the project context when the scene file path is unknown. Additionally, modified the AppCommand class in tk_maya/menu_generation.py to check for existing windows before running the callback, which prevents the creation of duplicate windows.