### PR TITLE
SG-35286 - Add new setting to customice the menu name

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -472,9 +472,10 @@ class MayaEngine(Engine):
         # add qt paths and dlls
         self._init_pyside()
 
-        # default menu name is Shotgun but this can be overriden
-        # in the configuration to be Sgtk in case of conflicts
-        self._menu_name = "Flow Production Tracking"
+        # default menu name is Flow Production Tracking but this can be overriden
+        # in the configuration to be a custom name or to be Sgtk in case of conflicts
+        self._menu_name = self.get_setting("menu_name", "Flow Production Tracking")
+
         if self.get_setting("use_sgtk_as_menu_name", False):
             self._menu_name = "Sgtk"
 

--- a/info.yml
+++ b/info.yml
@@ -74,6 +74,11 @@ configuration:
         description: Optionally choose to use 'Sgtk' as the primary menu name instead of 'Flow Production Tracking'
         default_value: false
 
+    menu_name:
+        type: str
+        description: Choose the name to use as the primary menu name. By default 'Flow Production Tracking'
+        default_value: 'Flow Production Tracking'
+
     launch_builtin_plugins:
         type: list
         description: Comma-separated list of tk-maya plugins to load when launching Maya. Use


### PR DESCRIPTION
Some of our users are reporting that the new Flow Production Tracking name for the main menu is a little confusing. It may look like 3 buttons instead of one.

This pull allows, via a new setting in the info.yml file, use a custom name for the menu.