### PR TITLE
SG-35286 Rename the short menu name from "Sgtk" to "FPTR"

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -475,8 +475,8 @@ class MayaEngine(Engine):
         # default menu name is Shotgun but this can be overriden
         # in the configuration to be Sgtk in case of conflicts
         self._menu_name = "Flow Production Tracking"
-        if self.get_setting("use_sgtk_as_menu_name", False):
-            self._menu_name = "Sgtk"
+        if self.get_setting("use_short_menu_name", False):
+            self._menu_name = "FPTR"
 
         self.__watcher = None
         if self.get_setting("automatic_context_switch", True):

--- a/info.yml
+++ b/info.yml
@@ -69,9 +69,9 @@ configuration:
                      empty if you do not wish the Maya project to be automatically set."
         allows_empty: True
 
-    use_sgtk_as_menu_name:
+    use_short_menu_name:
         type: bool
-        description: Optionally choose to use 'Sgtk' as the primary menu name instead of 'Flow Production Tracking'
+        description: Optionally choose to use "FPTR" as the primary menu name instead of "Flow Production Tracking"
         default_value: false
 
     launch_builtin_plugins:


### PR DESCRIPTION
_Sgtk_ does not make sense anymore since #105

- Rename the `use_sgtk_as_menu_name` setting to `use_short_menu_name`
- Rename the short menu name "**Sgtk**" to "**FPTR**"

----

Closes #110, Closes #112 