### PR TITLE
SG-36114 Add minimize button PoC

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -694,23 +694,24 @@ class MayaEngine(Engine):
 
         :returns: the created widget_class instance
         """
+        from sgtk.platform.qt import QtCore, QtGui
+
+        if not self.has_ui:
+            self.log_error(
+                "Sorry, this environment does not support UI display! Cannot show "
+                "the requested window '%s'." % title
+            )
+            return None
+    
+        # create the dialog:
+        dialog, widget = self._create_dialog_with_widget(title, *args, **kwargs)
+    
         if not sgtk.util.is_macos():
-            dialog = super().show_dialog(title, *args, **kwargs)
-            self.log_debug(">>> show_dialog: %s" % dialog)
-            dialog.setWindowFlags(sgtk.platform.qt.QtCore.Qt.Window | sgtk.platform.qt.QtCore.Qt.WindowMinimizeButtonHint)
-            return dialog
+            dialog.setWindowFlags(dialog.windowFlags() | QtGui.Qt.WindowMinimizeButtonHint)
+            dialog.show()
+
+            return widget
         else:
-            if not self.has_ui:
-                self.log_error(
-                    "Sorry, this environment does not support UI display! Cannot show "
-                    "the requested window '%s'." % title
-                )
-                return None
-
-            from sgtk.platform.qt import QtCore, QtGui
-
-            # create the dialog:
-            dialog, widget = self._create_dialog_with_widget(title, *args, **kwargs)
 
             # When using the recipe here to get Z-depth ordering correct we also
             # inherit another feature that results in window size and position being

--- a/engine.py
+++ b/engine.py
@@ -692,14 +692,14 @@ class MayaEngine(Engine):
 
         :returns: the created widget_class instance
         """
-        from sgtk.platform.qt import QtCore, QtGui
-
         if not self.has_ui:
             self.log_error(
                 "Sorry, this environment does not support UI display! Cannot show "
                 "the requested window '%s'." % title
             )
-            return None
+            return
+
+        from sgtk.platform.qt import QtCore, QtGui
 
         # create the dialog:
         dialog, widget = self._create_dialog_with_widget(title, *args, **kwargs)

--- a/engine.py
+++ b/engine.py
@@ -705,9 +705,12 @@ class MayaEngine(Engine):
         dialog, widget = self._create_dialog_with_widget(title, *args, **kwargs)
 
         if not sgtk.util.is_macos():
-            dialog.setWindowFlags(
-                dialog.windowFlags() | QtGui.Qt.WindowMinimizeButtonHint
-            )
+            window_flags = dialog.windowFlags()
+            
+            if self.get_setting("enable_dialogs_minimize_button", False):
+                window_flags |= QtGui.Qt.WindowMinimizeButtonHint
+
+            dialog.setWindowFlags(window_flags)
             dialog.show()
         else:
             # When using the recipe here to get Z-depth ordering correct we also

--- a/engine.py
+++ b/engine.py
@@ -709,8 +709,6 @@ class MayaEngine(Engine):
                 dialog.windowFlags() | QtGui.Qt.WindowMinimizeButtonHint
             )
             dialog.show()
-
-            return widget
         else:
             # When using the recipe here to get Z-depth ordering correct we also
             # inherit another feature that results in window size and position being
@@ -739,8 +737,8 @@ class MayaEngine(Engine):
             dialog.resize(self.__DIALOG_SIZE_CACHE[title])
             dialog.move(center_screen - dialog.rect().center())
 
-            # lastly, return the instantiated widget
-            return widget
+        # lastly, return the instantiated widget
+        return widget
 
     def _get_dialog_parent(self):
         """

--- a/engine.py
+++ b/engine.py
@@ -706,7 +706,7 @@ class MayaEngine(Engine):
 
         if not sgtk.util.is_macos():
             window_flags = dialog.windowFlags()
-            
+
             if self.get_setting("enable_dialogs_minimize_button", False):
                 window_flags |= QtGui.Qt.WindowMinimizeButtonHint
 

--- a/engine.py
+++ b/engine.py
@@ -697,7 +697,7 @@ class MayaEngine(Engine):
         if not sgtk.util.is_macos():
             dialog = super().show_dialog(title, *args, **kwargs)
             self.log_debug(">>> show_dialog: %s" % dialog)
-            dialog.setWindowFlags(sgtk.platform.qt.QtCore.Qt.Window | QtCore.Qt.WindowMinimizeButtonHint)
+            dialog.setWindowFlags(sgtk.platform.qt.QtCore.Qt.Window | sgtk.platform.qt.QtCore.Qt.WindowMinimizeButtonHint)
             return dialog
         else:
             if not self.has_ui:

--- a/engine.py
+++ b/engine.py
@@ -500,7 +500,6 @@ class MayaEngine(Engine):
 
         # only create the shotgun menu if not in batch mode and menu doesn't already exist
         if self.has_ui and not cmds.menu("ShotGridMenu", exists=True):
-
             self._menu_path = cmds.menu(
                 "ShotGridMenu",
                 label=self._menu_name,
@@ -584,7 +583,6 @@ class MayaEngine(Engine):
 
         # Run the series of app instance commands listed in the 'run_at_startup' setting.
         for app_setting_dict in self.get_setting("run_at_startup", []):
-
             app_instance_name = app_setting_dict["app_instance"]
             # Menu name of the command to run or '' to run all commands of the given app instance.
             setting_command_name = app_setting_dict["name"]
@@ -702,17 +700,18 @@ class MayaEngine(Engine):
                 "the requested window '%s'." % title
             )
             return None
-    
+
         # create the dialog:
         dialog, widget = self._create_dialog_with_widget(title, *args, **kwargs)
-    
+
         if not sgtk.util.is_macos():
-            dialog.setWindowFlags(dialog.windowFlags() | QtGui.Qt.WindowMinimizeButtonHint)
+            dialog.setWindowFlags(
+                dialog.windowFlags() | QtGui.Qt.WindowMinimizeButtonHint
+            )
             dialog.show()
 
             return widget
         else:
-
             # When using the recipe here to get Z-depth ordering correct we also
             # inherit another feature that results in window size and position being
             # remembered. This size/pos retention happens across app boundaries, so

--- a/engine.py
+++ b/engine.py
@@ -695,7 +695,10 @@ class MayaEngine(Engine):
         :returns: the created widget_class instance
         """
         if not sgtk.util.is_macos():
-            return super(MayaEngine, self).show_dialog(title, *args, **kwargs)
+            status, dialog = super().show_dialog(title, *args, **kwargs)
+            self.log_debug("show_dialog status: %s" % status)
+            dialog.setWindowFlags(QtCore.Qt.Window | QtCore.Qt.WindowMinimizeButtonHint)
+            return dialog
         else:
             if not self.has_ui:
                 self.log_error(

--- a/engine.py
+++ b/engine.py
@@ -695,8 +695,8 @@ class MayaEngine(Engine):
         :returns: the created widget_class instance
         """
         if not sgtk.util.is_macos():
-            status, dialog = super().show_dialog(title, *args, **kwargs)
-            self.log_debug("show_dialog status: %s" % status)
+            dialog = super().show_dialog(title, *args, **kwargs)
+            self.log_debug(">>> show_dialog: %s" % dialog)
             dialog.setWindowFlags(QtCore.Qt.Window | QtCore.Qt.WindowMinimizeButtonHint)
             return dialog
         else:

--- a/engine.py
+++ b/engine.py
@@ -697,7 +697,7 @@ class MayaEngine(Engine):
         if not sgtk.util.is_macos():
             dialog = super().show_dialog(title, *args, **kwargs)
             self.log_debug(">>> show_dialog: %s" % dialog)
-            dialog.setWindowFlags(QtCore.Qt.Window | QtCore.Qt.WindowMinimizeButtonHint)
+            dialog.setWindowFlags(sgtk.platform.qt.QtCore.Qt.Window | QtCore.Qt.WindowMinimizeButtonHint)
             return dialog
         else:
             if not self.has_ui:

--- a/info.yml
+++ b/info.yml
@@ -84,6 +84,11 @@ configuration:
         values:
             type: str
 
+    enable_dialogs_minimize_button:
+        type: bool
+        description: Enable the minimize button for Toolkit dialogs (experimental)
+        default_value: false
+
 # the Shotgun fields that this engine needs in order to operate correctly
 requires_shotgun_fields:
 

--- a/info.yml
+++ b/info.yml
@@ -86,7 +86,7 @@ configuration:
 
     enable_dialogs_minimize_button:
         type: bool
-        description: Enable the minimize button for Toolkit dialogs (experimental)
+        description: Enable the minimize button for Toolkit dialogs on Windows (experimental)
         default_value: false
 
 # the Shotgun fields that this engine needs in order to operate correctly


### PR DESCRIPTION
Adds `WindowMinimizeButtonHint` [WindowType](https://doc.qt.io/qtforpython-6/PySide6/QtCore/Qt.html#PySide6.QtCore.Qt.WindowType) to the engine dialog manager.

## How to use it

Add the `enable_dialogs_minimize_button` configuration in the tk-maya.yml settings file (in your config):

```yml
# project
settings.tk-maya.project:
  apps:
    ...
  enable_dialogs_minimize_button: true
  location: "@engines.tk-maya.location"
```

## Screenshots

_Added minimize button_

![image](https://github.com/user-attachments/assets/bf84a63e-5abd-4f2f-bcfa-e79a979180b9)

-------

_All TK dialogs are located at the botton_

![image](https://github.com/user-attachments/assets/7c623553-be26-4d95-b9b4-0068bb5a16a4)
