### PR TITLE
SG-38062 Add support for Maya 2026

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,6 +1,6 @@
 # Toolkit Engine for Maya
 
-![Supported Maya versions: 2023 - 2026](https://img.shields.io/badge/Maya-2026_|_2025_|_2024_|_2023-blue?logo=autodeskmaya&logoColor=f5f5f5)
+![Supported Maya versions: 2023 - 2026](https://img.shields.io/badge/Maya-2026_|_2025_|_2024_|_2023-blue?logo=autodeskmaya&logoColor=f5f5f5 "Support Maya versions")
 [![Supported VFX Platform: 2022 - 2025](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
 [![Supported Python versions: 3.9 - 3.11](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
 

--- a/README.md
+++ b/README.md
@@ -1,5 +1,9 @@
-[![VFX Platform](https://img.shields.io/badge/vfxplatform-2025%20%7C%202024%20%7C%202023%20%7C%202022-blue.svg)](http://www.vfxplatform.com/)
-[![Python](https://img.shields.io/badge/python-3.11%20%7C%203.10%20%7C%203.9-blue.svg)](https://www.python.org/)
+# Toolkit Engine for Maya
+
+![Maya](https://img.shields.io/badge/Maya-2026%20%7C%202025%20%7C%202024%20%7C%202023-blue.svg?logo=autodeskmaya)
+[![VFX Platform](https://img.shields.io/badge/VFX_Platform-2025%20%7C%202024%20%7C%202023%20%7C%202022-blue.svg)](http://www.vfxplatform.com/)
+[![Python](https://img.shields.io/badge/Python-3.11%20%7C%203.10%20%7C%203.9-blue.svg?logo=python)](https://www.python.org/)
+
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-maya?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=28&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)
 [![Linting](https://img.shields.io/badge/PEP8%20by-Hound%20CI-a873d1.svg)](https://houndci.com)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Toolkit Engine for Maya
 
-![Maya](https://img.shields.io/badge/Maya-2026%20%7C%202025%20%7C%202024%20%7C%202023-blue.svg?logo=autodeskmaya)
-[![VFX Platform](https://img.shields.io/badge/VFX_Platform-2025%20%7C%202024%20%7C%202023%20%7C%202022-blue.svg)](http://www.vfxplatform.com/)
-[![Python](https://img.shields.io/badge/Python-3.11%20%7C%203.10%20%7C%203.9-blue.svg?logo=python)](https://www.python.org/)
+![Supported Maya versions: 2023 - 2026](https://img.shields.io/badge/Maya-2026_|_2025_|_2024_|_2023-blue?logo=autodeskmaya&logoColor=f5f5f5)
+[![Supported VFX Platform: 2022 - 2025](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
+[![Supported Python versions: 3.9 - 3.11](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
 
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-maya?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=28&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/engine.py
+++ b/engine.py
@@ -387,13 +387,6 @@ class MayaEngine(Engine):
             maya_ver = maya_ver[5:]
         if maya_ver.startswith(
             (
-                "2014",
-                "2015",
-                "2016",
-                "2017",
-                "2018",
-                "2019",
-                "2020",
                 "2022",
                 "2023",
                 "2024",
@@ -402,24 +395,37 @@ class MayaEngine(Engine):
         ):
             self.logger.debug("Running Maya version %s", maya_ver)
 
-            # In the case of Maya 2018 on Windows, we have the possility of locking
+            # In the case of Maya on Windows, we have the possility of locking
             # up if we allow the PySide shim to import QtWebEngineWidgets. We can
             # stop that happening here by setting the environment variable.
             version_num = int(maya_ver[0:4])
 
-            if version_num >= 2018 and current_os.startswith("win"):
+            if current_os.startswith("win"):
                 self.logger.debug(
-                    "Maya 2018+ on Windows can deadlock if QtWebEngineWidgets "
+                    "Maya on Windows can deadlock if QtWebEngineWidgets "
                     "is imported. Setting SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT=1..."
                 )
                 os.environ["SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT"] = "1"
-        elif maya_ver.startswith(("2012", "2013")):
+        elif maya_ver.startswith(
+            (
+                "2012",
+                "2013",
+                "2014",
+                "2015",
+                "2016",
+                "2017",
+                "2018",
+                "2019",
+                "2020",
+            )
+        ):
             # We won't be able to rely on the warning dialog below, because Maya
-            # older than 2014 doesn't ship with PySide. Instead, we just have to
-            # raise an exception so that we bail out here with an error message
-            # that will hopefully make sense for the user.
+            # older than 2022 ships Python 2. And older versions come with Qt4.
+            # Instead, we just have to raise an exception so that we bail out
+            # here with an error message that will hopefully make sense for the
+            # user.
             msg = (
-                "PTR integration is not compatible with Maya versions older than 2014."
+                "PTR integration is not compatible with Maya versions older than 2022."
             )
             raise sgtk.TankError(msg)
         else:

--- a/engine.py
+++ b/engine.py
@@ -391,6 +391,7 @@ class MayaEngine(Engine):
                 "2023",
                 "2024",
                 "2025",
+                "2026",
             )
         ):
             self.logger.debug("Running Maya version %s", maya_ver)

--- a/info.yml
+++ b/info.yml
@@ -25,7 +25,7 @@ configuration:
                      it isn't yet fully supported and tested with Toolkit.  To disable the warning
                      dialog for the version you are testing, it is recomended that you set this
                      value to the current major version + 1."
-        default_value: 2015
+        default_value: 2026
 
     debug_logging:
         type: bool

--- a/startup.py
+++ b/startup.py
@@ -26,7 +26,7 @@ class MayaLauncher(SoftwareLauncher):
     # matching against supplied versions and products. Similar to the glob
     # strings, these allow us to alter the regex matching for any of the
     # variable components of the path in one place
-    COMPONENT_REGEX_LOOKUP = {"version": r"[\d.]+", "mach": r"x\d+"}
+    COMPONENT_REGEX_LOOKUP = {"version": r"[\d\.]+", "mach": r"x\d+"}
 
     # This dictionary defines a list of executable template strings for each
     # of the supported operating systems. The templates are used for both

--- a/startup.py
+++ b/startup.py
@@ -55,7 +55,7 @@ class MayaLauncher(SoftwareLauncher):
         """
         The minimum software version that is supported by the launcher.
         """
-        return "2014"
+        return "2022"
 
     def prepare_launch(self, exec_path, args, file_to_open=None):
         """


### PR DESCRIPTION
Update the newest supported version from `2025` to `2026`.

Also, apply the following changes:

- Update the oldest compatible version from `2014` to `2022` (first version with Python 3)
- Update badges
- Fixup wrong regexp for detecting app versions
