### PR TITLE
SG-32814 Review and unify code handling supported DCC versions

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -387,13 +387,6 @@ class MayaEngine(Engine):
             maya_ver = maya_ver[5:]
         if maya_ver.startswith(
             (
-                "2014",
-                "2015",
-                "2016",
-                "2017",
-                "2018",
-                "2019",
-                "2020",
                 "2022",
                 "2023",
                 "2024",
@@ -402,24 +395,37 @@ class MayaEngine(Engine):
         ):
             self.logger.debug("Running Maya version %s", maya_ver)
 
-            # In the case of Maya 2018 on Windows, we have the possility of locking
+            # In the case of Maya on Windows, we have the possility of locking
             # up if we allow the PySide shim to import QtWebEngineWidgets. We can
             # stop that happening here by setting the environment variable.
             version_num = int(maya_ver[0:4])
 
-            if version_num >= 2018 and current_os.startswith("win"):
+            if current_os.startswith("win"):
                 self.logger.debug(
-                    "Maya 2018+ on Windows can deadlock if QtWebEngineWidgets "
+                    "Maya on Windows can deadlock if QtWebEngineWidgets "
                     "is imported. Setting SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT=1..."
                 )
                 os.environ["SHOTGUN_SKIP_QTWEBENGINEWIDGETS_IMPORT"] = "1"
-        elif maya_ver.startswith(("2012", "2013")):
+        elif maya_ver.startswith(
+            (
+                "2012",
+                "2013",
+                "2014",
+                "2015",
+                "2016",
+                "2017",
+                "2018",
+                "2019",
+                "2020",
+            )
+        ):
             # We won't be able to rely on the warning dialog below, because Maya
-            # older than 2014 doesn't ship with PySide. Instead, we just have to
-            # raise an exception so that we bail out here with an error message
-            # that will hopefully make sense for the user.
+            # older than 2022 ships Python 2. And older versions come with Qt4.
+            # Instead, we just have to raise an exception so that we bail out
+            # here with an error message that will hopefully make sense for the
+            # user.
             msg = (
-                "PTR integration is not compatible with Maya versions older than 2014."
+                "PTR integration is not compatible with Maya versions older than 2022."
             )
             raise sgtk.TankError(msg)
         else:

--- a/engine.py
+++ b/engine.py
@@ -391,6 +391,7 @@ class MayaEngine(Engine):
                 "2023",
                 "2024",
                 "2025",
+                "2026",
             )
         ):
             self.logger.debug("Running Maya version %s", maya_ver)

--- a/engine.py
+++ b/engine.py
@@ -425,7 +425,7 @@ For information regarding support engine versions, please visit this page:
                             ),
                         ),
                     )
-                except:
+                except:  # nosec B110
                     # It is unlikely that the above message will go through
                     # on old versions of Maya (Python2, Qt4, ...).
                     # But there is nothing more we can do here.
@@ -469,7 +469,7 @@ For information regarding support engine versions, please visit this page:
                             version=VERSION_OLDEST_COMPATIBLE,
                         ),
                     )
-                except:
+                except:  # nosec B110
                     # It is unlikely that the above message will go through
                     # on old versions of Maya (Python2, Qt4, ...).
                     # But there is nothing more we can do here.

--- a/engine.py
+++ b/engine.py
@@ -415,7 +415,7 @@ For information regarding support engine versions, please visit this page:
                             70
                         ),
                         message=message.replace(
-                            # Precense of \n breaks the Rich Text Format
+                            # Presence of \n breaks the Rich Text Format
                             "\n",
                             "<br>",
                         ).format(
@@ -458,7 +458,7 @@ For information regarding support engine versions, please visit this page:
                             70
                         ),
                         message=message.replace(
-                            # Precense of \n breaks the Rich Text Format
+                            # Presence of \n breaks the Rich Text Format
                             "\n",
                             "<br>",
                         ).format(
@@ -510,7 +510,7 @@ For information regarding support engine versions, please visit this page:
 {url_doc_supported_versions}
                     """.strip()
                     .replace(
-                        # Precense of \n breaks the Rich Text Format
+                        # Presence of \n breaks the Rich Text Format
                         "\n",
                         "<br>",
                     )
@@ -523,13 +523,11 @@ For information regarding support engine versions, please visit this page:
                     ),
                 )
 
-        elif maya_major_version < VERSION_NEWEST_SUPPORTED:
+        elif maya_major_version <= VERSION_NEWEST_SUPPORTED:
             # Within the range of supported versions
             self.logger.debug(f"Running Maya version {maya_ver}")
 
-        else:
-            # Newer than the newest supported version
-            # This is an untested version of Maya.
+        else:  # Newer than the newest supported version (untested)
             self.logger.warning(
                 "Flow Production Tracking has not yet been fully tested with "
                 "{product} version {version}.".format(
@@ -564,7 +562,7 @@ Please report any issues to:
 {support_url}
                     """.strip()
                     .replace(
-                        # Precense of \n breaks the Rich Text Format
+                        # Presence of \n breaks the Rich Text Format
                         "\n",
                         "<br>",
                     )

--- a/engine.py
+++ b/engine.py
@@ -29,6 +29,8 @@ from sgtk.platform import Engine
 VERSION_OLDEST_COMPATIBLE = 2023
 VERSION_OLDEST_SUPPORTED = 2023
 VERSION_NEWEST_SUPPORTED = 2026
+# Caution: make sure compatibility_dialog_min_version default value in info.yml
+# is equal to VERSION_NEWEST_SUPPORTED
 
 # Although the engine has logging already, this logger is needed for callback based logging
 # where an engine may not be present.
@@ -529,7 +531,7 @@ For information regarding support engine versions, please visit this page:
                 "Flow Production Tracking has not yet been fully tested with "
                 "{product} version {version}.".format(
                     product="Maya",
-                    version=VERSION_NEWEST_SUPPORTED,
+                    version=maya_major_version,
                 )
             )
 
@@ -540,7 +542,6 @@ For information regarding support engine versions, please visit this page:
                 and maya_major_version
                 >= self.get_setting(
                     "compatibility_dialog_min_version",
-                    default=VERSION_NEWEST_SUPPORTED,
                 )
             ):
                 # make sure we only show it once per session:
@@ -569,7 +570,7 @@ Please report any issues to:
                     .format(
                         product="Maya",
                         support_url='<a href="{u}">{u}</a>'.format(u=sgtk.support_url),
-                        version=VERSION_NEWEST_SUPPORTED,
+                        version=maya_major_version,
                     ),
                 )
 

--- a/engine.py
+++ b/engine.py
@@ -467,11 +467,10 @@ class MayaEngine(Engine):
                     title="Warning - Flow Production Tracking Compatibility!".ljust(70),
                     message=compatibility_warning_msg.replace(
                         # Precense of \n breaks the Rich Text Format
-                        "\n", "<br>"
+                        "\n",
+                        "<br>",
                     ).format(
-                        support_url='<a href="{u}">{u}</a>'.format(
-                            u=sgtk.support_url
-                        ),
+                        support_url='<a href="{u}">{u}</a>'.format(u=sgtk.support_url),
                         url_doc_supported_versions='<a href="{u}">{u}</a>'.format(
                             u=url_doc_supported_versions,
                         ),

--- a/engine.py
+++ b/engine.py
@@ -409,7 +409,9 @@ For information regarding support engine versions, please visit this page:
                         button="Ok",
                         icon="critical",
                         # Note, title is padded to try to ensure dialog isn't insanely narrow!
-                        title="Error - Flow Production Tracking Compatibility!".ljust(70),
+                        title="Error - Flow Production Tracking Compatibility!".ljust(
+                            70
+                        ),
                         message=compatibility_warning_msg.replace(
                             # Precense of \n breaks the Rich Text Format
                             "\n",
@@ -445,7 +447,9 @@ For information regarding support engine versions, please visit this page:
                         button="Ok",
                         icon="critical",
                         # Note, title is padded to try to ensure dialog isn't insanely narrow!
-                        title="Error - Flow Production Tracking Compatibility!".ljust(70),
+                        title="Error - Flow Production Tracking Compatibility!".ljust(
+                            70
+                        ),
                         message=message.replace(
                             # Precense of \n breaks the Rich Text Format
                             "\n",
@@ -497,11 +501,13 @@ You can continue to use Toolkit but you may experience bugs or instabilities.
 
 For information regarding support engine versions, please visit this page:
 {url_doc_supported_versions}
-                    """.strip().replace(
+                    """.strip()
+                    .replace(
                         # Precense of \n breaks the Rich Text Format
                         "\n",
                         "<br>",
-                    ).format(
+                    )
+                    .format(
                         product="Maya",
                         url_doc_supported_versions='<a href="{u}">{u}</a>'.format(
                             u=url_doc_supported_versions,
@@ -527,9 +533,9 @@ For information regarding support engine versions, please visit this page:
 
             if (
                 # determine if we should show the compatibility warning dialog
-                self.has_ui and
-                "SGTK_COMPATIBILITY_DIALOG_SHOWN" not in os.environ and
-                maya_major_version
+                self.has_ui
+                and "SGTK_COMPATIBILITY_DIALOG_SHOWN" not in os.environ
+                and maya_major_version
                 >= self.get_setting(
                     "compatibility_dialog_min_version",
                     default=VERSION_NEWEST_SUPPORTED,
@@ -550,15 +556,15 @@ You can continue to use Toolkit but you may experience bugs or instabilities.
 
 Please report any issues to:
 {support_url}
-                    """.strip().replace(
+                    """.strip()
+                    .replace(
                         # Precense of \n breaks the Rich Text Format
                         "\n",
                         "<br>",
-                    ).format(
+                    )
+                    .format(
                         product="Maya",
-                        support_url='<a href="{u}">{u}</a>'.format(
-                            u=sgtk.support_url
-                        ),
+                        support_url='<a href="{u}">{u}</a>'.format(u=sgtk.support_url),
                         version=VERSION_NEWEST_SUPPORTED,
                     ),
                 )

--- a/engine.py
+++ b/engine.py
@@ -543,9 +543,7 @@ For information regarding support engine versions, please visit this page:
                 self.has_ui
                 and "SGTK_COMPATIBILITY_DIALOG_SHOWN" not in os.environ
                 and maya_major_version
-                >= self.get_setting(
-                    "compatibility_dialog_min_version",
-                )
+                >= self.get_setting("compatibility_dialog_min_version")
             ):
                 # make sure we only show it once per session:
                 os.environ["SGTK_COMPATIBILITY_DIALOG_SHOWN"] = "1"

--- a/engine.py
+++ b/engine.py
@@ -405,16 +405,16 @@ For information regarding support engine versions, please visit this page:
 {url_doc_supported_versions}.
             """.strip()
 
-            try:
-                if self.has_ui:
+            if self.has_ui:
+                try:
                     cmds.confirmDialog(
                         button="Ok",
                         icon="critical",
-                        # Note, title is padded to try to ensure dialog isn't insanely narrow!
+                        # Padding to try to prevent the dialog being insanely narrow
                         title="Error - Flow Production Tracking Compatibility!".ljust(
                             70
                         ),
-                        message=compatibility_warning_msg.replace(
+                        message=message.replace(
                             # Precense of \n breaks the Rich Text Format
                             "\n",
                             "<br>",
@@ -425,13 +425,18 @@ For information regarding support engine versions, please visit this page:
                             ),
                         ),
                     )
-            finally:
-                raise sgtk.TankError(
-                    message.format(
-                        product="Maya",
-                        url_doc_supported_versions=url_doc_supported_versions,
-                    )
+                except:
+                    # It is unlikely that the above message will go through
+                    # on old versions of Maya (Python2, Qt4, ...).
+                    # But there is nothing more we can do here.
+                    pass
+
+            raise sgtk.TankError(
+                message.format(
+                    product="Maya",
+                    url_doc_supported_versions=url_doc_supported_versions,
                 )
+            )
 
         if maya_major_version < VERSION_OLDEST_COMPATIBLE:
             # Older that the oldest known compatible version
@@ -449,7 +454,7 @@ For information regarding support engine versions, please visit this page:
                         button="Ok",
                         icon="critical",
                         title="Error - Flow Production Tracking Compatibility!".ljust(
-                            # Note, title is padded to try to ensure dialog isn't insanely narrow!
+                            # Padding to try to prevent the dialog being insanely narrow
                             70
                         ),
                         message=message.replace(
@@ -465,11 +470,9 @@ For information regarding support engine versions, please visit this page:
                         ),
                     )
                 except:
-                    # We probably won't be able to rely on the warning dialog,
-                    # because Maya older than 2022 ships Python 2. And older
-                    # versions come with Qt4.
-                    # So, we raise an exception cases with an error message that
-                    # will hopefully make sense for the user.
+                    # It is unlikely that the above message will go through
+                    # on old versions of Maya (Python2, Qt4, ...).
+                    # But there is nothing more we can do here.
                     pass
 
             raise sgtk.TankError(
@@ -495,7 +498,7 @@ For information regarding support engine versions, please visit this page:
                     button="Ok",
                     icon="warning",
                     title="Warning - Flow Production Tracking Compatibility!".ljust(
-                        # Note, title is padded to try to ensure dialog isn't insanely narrow!
+                        # Padding to try to prevent the dialog being insanely narrow
                         70
                     ),
                     message="""
@@ -551,7 +554,7 @@ For information regarding support engine versions, please visit this page:
                     button="Ok",
                     icon="warning",
                     title="Warning - Flow Production Tracking Compatibility!".ljust(
-                        # Note, title is padded to try to ensure dialog isn't insanely narrow!
+                        # Padding to try to prevent the dialog being insanely narrow
                         70
                     ),
                     message="""

--- a/engine.py
+++ b/engine.py
@@ -446,8 +446,8 @@ For information regarding support engine versions, please visit this page:
                     cmds.confirmDialog(
                         button="Ok",
                         icon="critical",
-                        # Note, title is padded to try to ensure dialog isn't insanely narrow!
                         title="Error - Flow Production Tracking Compatibility!".ljust(
+                            # Note, title is padded to try to ensure dialog isn't insanely narrow!
                             70
                         ),
                         message=message.replace(
@@ -492,8 +492,10 @@ For information regarding support engine versions, please visit this page:
                 cmds.confirmDialog(
                     button="Ok",
                     icon="warning",
-                    # Note, title is padded to try to ensure dialog isn't insanely narrow!
-                    title="Warning - Flow Production Tracking Compatibility!".ljust(70),
+                    title="Warning - Flow Production Tracking Compatibility!".ljust(
+                        # Note, title is padded to try to ensure dialog isn't insanely narrow!
+                        70
+                    ),
                     message="""
 Flow Production Tracking no longer supports {product} versions older than
 {version}.
@@ -547,8 +549,10 @@ For information regarding support engine versions, please visit this page:
                 cmds.confirmDialog(
                     button="Ok",
                     icon="warning",
-                    # Note, title is padded to try to ensure dialog isn't insanely narrow!
-                    title="Warning - Flow Production Tracking Compatibility!".ljust(70),
+                    title="Warning - Flow Production Tracking Compatibility!".ljust(
+                        # Note, title is padded to try to ensure dialog isn't insanely narrow!
+                        70
+                    ),
                     message="""
 Flow Production Tracking has not yet been fully tested with {product} version
 {version}.

--- a/info.yml
+++ b/info.yml
@@ -25,7 +25,6 @@ configuration:
                      it isn't yet fully supported and tested with Toolkit.  To disable the warning
                      dialog for the version you are testing, it is recomended that you set this
                      value to the current major version + 1."
-        default_value: 2026
 
     debug_logging:
         type: bool

--- a/info.yml
+++ b/info.yml
@@ -25,6 +25,7 @@ configuration:
                      it isn't yet fully supported and tested with Toolkit.  To disable the warning
                      dialog for the version you are testing, it is recomended that you set this
                      value to the current major version + 1."
+        default_value: 2026
 
     debug_logging:
         type: bool

--- a/info.yml
+++ b/info.yml
@@ -23,7 +23,7 @@ configuration:
         type: int
         description: "Specify the minimum Application major version that will prompt a warning if
                      it isn't yet fully supported and tested with Toolkit.  To disable the warning
-                     dialog for the version you are testing, it is recomended that you set this
+                     dialog for the version you are testing, it is recommended that you set this
                      value to the current major version + 1."
         default_value: 2026
 

--- a/info.yml
+++ b/info.yml
@@ -25,7 +25,7 @@ configuration:
                      it isn't yet fully supported and tested with Toolkit.  To disable the warning
                      dialog for the version you are testing, it is recomended that you set this
                      value to the current major version + 1."
-        default_value: 2015
+        default_value: 2026
 
     debug_logging:
         type: bool

--- a/startup.py
+++ b/startup.py
@@ -26,7 +26,7 @@ class MayaLauncher(SoftwareLauncher):
     # matching against supplied versions and products. Similar to the glob
     # strings, these allow us to alter the regex matching for any of the
     # variable components of the path in one place
-    COMPONENT_REGEX_LOOKUP = {"version": r"[\d.]+", "mach": r"x\d+"}
+    COMPONENT_REGEX_LOOKUP = {"version": r"[\d\.]+", "mach": r"x\d+"}
 
     # This dictionary defines a list of executable template strings for each
     # of the supported operating systems. The templates are used for both

--- a/startup.py
+++ b/startup.py
@@ -15,6 +15,10 @@ import sgtk
 from sgtk.platform import SoftwareLauncher, SoftwareVersion, LaunchInformation
 
 
+# Maya versions compatibility constants
+VERSION_OLDEST_COMPATIBLE = 2022
+
+
 class MayaLauncher(SoftwareLauncher):
     """
     Handles launching Maya executables. Automatically starts up
@@ -55,7 +59,7 @@ class MayaLauncher(SoftwareLauncher):
         """
         The minimum software version that is supported by the launcher.
         """
-        return "2022"
+        return str(VERSION_OLDEST_COMPATIBLE)
 
     def prepare_launch(self, exec_path, args, file_to_open=None):
         """

--- a/startup.py
+++ b/startup.py
@@ -55,7 +55,7 @@ class MayaLauncher(SoftwareLauncher):
         """
         The minimum software version that is supported by the launcher.
         """
-        return "2014"
+        return "2022"
 
     def prepare_launch(self, exec_path, args, file_to_open=None):
         """


### PR DESCRIPTION
Differentiate warning messages between the oldest compatible version and the oldest supported version.

# Changes aligned with other TK engines

- shotgunsoftware/tk-3dsmax#49
- shotgunsoftware/tk-alias#215
- shotgunsoftware/tk-houdini#81
- shotgunsoftware/tk-mari#30
- shotgunsoftware/tk-motionbuilder#36
- shotgunsoftware/tk-nuke#116
- shotgunsoftware/tk-vred#134


# Screenshots

Note: Please ignore the exact versions in the screenshots below. I had to tweak the code to issue those. 

* Error message when Maya version is older than the oldest **compatible** version
  ![2025-05-06_15-21](https://github.com/user-attachments/assets/cf3fa99e-252b-4d8a-bbf9-c6168d6dcdc3)

* Warning message when Maya version is older than the oldest **supported** version
  ![2025-05-06_15-12](https://github.com/user-attachments/assets/aaad56f3-cee0-4bc6-b879-cecb62529345)

* Warning message when Maya version is newer than the newest **supported** version
  ![2025-05-06_15-13](https://github.com/user-attachments/assets/a0a90531-ba79-466e-82b2-a5acad9576a2)












