### PR TITLE
SG-42442 support maya 2027

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Toolkit Engine for Maya
 
 ![Supported Maya versions: 2024 - 2027](https://img.shields.io/badge/Maya-2024_--_2027-blue?logo=autodeskmaya&logoColor=f5f5f5 "Support Maya versions")
-[![Supported VFX Platform: 2023 - 2026](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
-[![Supported Python versions: 3.9 - 3.11](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
+[![Supported VFX Platform: 2023 - 2026](https://img.shields.io/badge/VFX_Platform-2026_|_2025_|_2024_|_2023-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
+[![Supported Python versions: 3.9 - 3.13](https://img.shields.io/badge/Python-3.13_|_3.11_|_3.10|_3.9-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
 
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-maya?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=28&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 # Toolkit Engine for Maya
 
-![Supported Maya versions: 2023 - 2026](https://img.shields.io/badge/Maya-2023_--_2026-blue?logo=autodeskmaya&logoColor=f5f5f5 "Support Maya versions")
-[![Supported VFX Platform: 2022 - 2025](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
+![Supported Maya versions: 2024 - 2027](https://img.shields.io/badge/Maya-2024_--_2027-blue?logo=autodeskmaya&logoColor=f5f5f5 "Support Maya versions")
+[![Supported VFX Platform: 2023 - 2026](https://img.shields.io/badge/VFX_Platform-2025_|_2024_|_2023_|_2022-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
 [![Supported Python versions: 3.9 - 3.11](https://img.shields.io/badge/Python-3.11_|_3.10_|_3.9-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
 
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-maya?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=28&branchName=master)

--- a/README.md
+++ b/README.md
@@ -1,8 +1,8 @@
 # Toolkit Engine for Maya
 
-![Supported Maya versions: 2024 - 2027](https://img.shields.io/badge/Maya-2024_--_2027-blue?logo=autodeskmaya&logoColor=f5f5f5 "Support Maya versions")
-[![Supported VFX Platform: 2023 - 2026](https://img.shields.io/badge/VFX_Platform-2026_|_2025_|_2024_|_2023-blue)](http://www.vfxplatform.com/ "Supported VFX Platform")
-[![Supported Python versions: 3.9 - 3.13](https://img.shields.io/badge/Python-3.13_|_3.11_|_3.10|_3.9-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
+![Supported Maya versions: 2024 - 2027](https://img.shields.io/badge/Maya-2024_--_2027-blue?logo=autodeskmaya&logoColor=f5f5f5 "Supported Maya versions")
+[![Supported VFX Platform: CY2022 - CY2026](https://img.shields.io/badge/VFX_Reference_Platform-CY2022_|_CY2023_|_CY2024_|_CY2025_|_CY2026-blue)](http://www.vfxplatform.com/ "Supported VFX Reference Platform versions")
+[![Supported Python versions: 3.9, 3.10, 3.11, 3.13](https://img.shields.io/badge/Python-3.9_|_3.10_|_3.11_|_3.13-blue?logo=python&logoColor=f5f5f5)](https://www.python.org/ "Supported Python versions")
 
 [![Build Status](https://dev.azure.com/shotgun-ecosystem/Toolkit/_apis/build/status/Engines/tk-maya?branchName=master)](https://dev.azure.com/shotgun-ecosystem/Toolkit/_build/latest?definitionId=28&branchName=master)
 [![Code style: black](https://img.shields.io/badge/code%20style-black-000000.svg)](https://github.com/psf/black)

--- a/engine.py
+++ b/engine.py
@@ -26,9 +26,9 @@ import maya.mel as mel
 from sgtk.platform import Engine
 
 # Maya versions compatibility constants
-VERSION_OLDEST_COMPATIBLE = 2022
-VERSION_OLDEST_SUPPORTED = 2023
-VERSION_NEWEST_SUPPORTED = 2026
+VERSION_OLDEST_COMPATIBLE = 2023
+VERSION_OLDEST_SUPPORTED = 2024
+VERSION_NEWEST_SUPPORTED = 2027
 # Caution: make sure compatibility_dialog_min_version default value in info.yml
 # is equal to VERSION_NEWEST_SUPPORTED
 

--- a/info.yml
+++ b/info.yml
@@ -25,7 +25,7 @@ configuration:
                      it isn't yet fully supported and tested with Toolkit.  To disable the warning
                      dialog for the version you are testing, it is recommended that you set this
                      value to the current major version + 1."
-        default_value: 2026
+        default_value: 2027
 
     debug_logging:
         type: bool


### PR DESCRIPTION
This pull request updates the supported versions for Maya and the VFX Platform across the project documentation, configuration, and code. The main focus is to advance support to newer versions and drop support for older ones, ensuring the engine remains current with industry standards.

Version support updates:

* Updated the supported Maya versions in `README.md` to 2024–2027, and revised the VFX Platform badge to reflect support for 2023–2026.
* Changed version compatibility constants in `engine.py` to set the oldest compatible Maya version to 2023, the oldest supported to 2024, and the newest supported to 2027.
* Updated the `compatibility_dialog_min_version` default value in `info.yml` to 2027 to match the new support window.