### PR TITLE
SG-43467 Support background publish in Maya

### DIFF
--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -324,11 +324,12 @@ class MayaSessionPublishPlugin(HookBaseClass):
         if self._is_deferred_to_bg(item):
             # store the current session path in the root item properties
             # it will be used later in the background process to open the file before running the publishing actions
-            # NOTE: Because the collector has filtered for "maya session" items, we know that the parent
-            #       of this item will be the root item.
-            if "session_path" not in item.parent.properties:
-                item.parent.properties["session_path"] = path
-                item.parent.properties["session_name"] = (
+            root = item
+            while not root.is_root:
+                root = root.parent
+            if root.properties.get("session_path") != path:
+                root.properties["session_path"] = path
+                root.properties["session_name"] = (
                     "Maya Session - {task_name}, {entity_type} {entity_name} - {file_name}".format(
                         task_name=item.context.task["name"],
                         entity_type=item.context.entity["type"],

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -349,10 +349,12 @@ class MayaSessionPublishPlugin(HookBaseClass):
                 _maya_find_additional_session_dependencies()
             )
 
-        # let the base class register the publish
-        # NOTE: base class publish will gate publishing based on background publish
-        #       status so we will not explicitly gate this here.
-        super().publish(settings, item)
+            # let the base class register the publish
+            super().publish(settings, item)
+        else:
+            self.logger.info(
+                "Background publish enabled — deferring publish registration to the background process."
+            )
 
     def finalize(self, settings, item):
         """
@@ -365,10 +367,12 @@ class MayaSessionPublishPlugin(HookBaseClass):
         :param item: Item to process
         """
 
-        # do the base class finalization
-        # NOTE: base class publish will gate finalizing based on background publish
-        #       status so we will not explicitly gate this here.
-        super().finalize(settings, item)
+        if not self._is_deferred_to_bg(item):
+            super().finalize(settings, item)
+        else:
+            self.logger.info(
+                "Background publish enabled — deferring finalize to the background process."
+            )
 
         if not self._in_bg_process(item):
             # Only increment the version if we are not in a background publish

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -84,7 +84,9 @@ class MayaSessionPublishPlugin(HookBaseClass):
         however only the most recent publish will be available to other users.
         Warnings will be provided during validation if there are previous
         publishes.
-        """ % (loader_url,)
+        """ % (
+            loader_url,
+        )
 
     @property
     def settings(self):
@@ -316,17 +318,41 @@ class MayaSessionPublishPlugin(HookBaseClass):
         path = sgtk.util.ShotgunPath.normalize(_session_path())
 
         # ensure the session is saved
-        _save_session(path)
+        # NOTE: skip this if we're in a background publish as the session has already been saved
+        if not self._in_bg_process(item):
+            _save_session(path)
+
+        # store the session path to ensure the background process can access the work file
+        if self._is_deferred_to_bg(item):
+            # store the current session path in the root item properties
+            # it will be used later in the background process to open the file before running the publishing actions
+            # NOTE: Because the collector has filtered for "maya session" items, we know that the parent
+            #       of this item will be the root item.
+            if "session_path" not in item.parent.properties:
+                item.parent.properties["session_path"] = path
+                item.parent.properties["session_name"] = (
+                    "Maya Session - {task_name}, {entity_type} {entity_name} - {file_name}".format(
+                        task_name=item.context.task["name"],
+                        entity_type=item.context.entity["type"],
+                        entity_name=item.context.entity["name"],
+                        file_name=os.path.basename(path),
+                    )
+                )
 
         # update the item with the saved session path
         item.properties["path"] = path
 
-        # add dependencies for the base class to register when publishing
-        item.properties["publish_dependencies"] = (
-            _maya_find_additional_session_dependencies()
-        )
+        if not self._is_deferred_to_bg(item):
+            # add dependencies for the base class to register when publishing
+            # (skip computing this when deferring - the base class would just
+            # discard it without using it, and this can be slow on heavy scenes)
+            item.properties["publish_dependencies"] = (
+                _maya_find_additional_session_dependencies()
+            )
 
         # let the base class register the publish
+        # NOTE: base class publish will gate publishing based on background publish
+        #       status so we will not explicitly gate this here.
         super().publish(settings, item)
 
     def finalize(self, settings, item):
@@ -341,9 +367,33 @@ class MayaSessionPublishPlugin(HookBaseClass):
         """
 
         # do the base class finalization
+        # NOTE: base class publish will gate finalizing based on background publish
+        #       status so we will not explicitly gate this here.
         super().finalize(settings, item)
 
-        self._save_to_next_version(item.get_property("path"), item, _save_session)
+        if not self._in_bg_process(item):
+            # Only increment the version if we are not in a background publish
+            # (This will have already been done by the foreground process and we do not
+            #  want to do it twice.)
+            self._save_to_next_version(item.get_property("path"), item, _save_session)
+
+    def _in_bg_process(self, item) -> bool:
+        """Return True if we are currently in a background publish process."""
+        root = item
+        while not root.is_root:
+            root = root.parent
+        return bool(root.properties.get("in_bg_process"))
+
+    def _is_deferred_to_bg(self, item) -> bool:
+        """Return True if publish item or any ancestor of it has bg publish enabled
+        but we are not currently in a bg process.
+        """
+        root = item
+        while not root.is_root:
+            root = root.parent
+        return bool(root.properties.get("bg_processing")) and not bool(
+            root.properties.get("in_bg_process")
+        )
 
 
 def _maya_find_additional_session_dependencies():

--- a/hooks/tk-multi-publish2/basic/publish_session.py
+++ b/hooks/tk-multi-publish2/basic/publish_session.py
@@ -84,9 +84,7 @@ class MayaSessionPublishPlugin(HookBaseClass):
         however only the most recent publish will be available to other users.
         Warnings will be provided during validation if there are previous
         publishes.
-        """ % (
-            loader_url,
-        )
+        """ % (loader_url,)
 
     @property
     def settings(self):

--- a/hooks/tk-multi-publish2/basic/publish_session_geometry.py
+++ b/hooks/tk-multi-publish2/basic/publish_session_geometry.py
@@ -281,7 +281,7 @@ class MayaSessionGeometryPublishPlugin(HookBaseClass):
             try:
                 # Load Alembic plugin if it isn't already
                 if not cmds.pluginInfo("AbcExport", query=True, loaded=True):
-                    cmds.loadPlugin("AbcExport")
+                    cmds.loadPlugin(plugin)
                 self.parent.log_debug("Executing command: %s" % abc_export_cmd)
                 mel.eval(abc_export_cmd)
             except Exception as e:
@@ -306,7 +306,7 @@ class MayaSessionGeometryPublishPlugin(HookBaseClass):
             super().finalize(settings, item)
         else:
             self.logger.info(
-                "Background publish enabled — deferring finalize to the background process."
+                "Background publish enabled — deferring alembic publish finalize to the background process."
             )
 
     def _is_deferred_to_bg(self, item) -> bool:

--- a/hooks/tk-multi-publish2/basic/publish_session_geometry.py
+++ b/hooks/tk-multi-publish2/basic/publish_session_geometry.py
@@ -237,51 +237,88 @@ class MayaSessionGeometryPublishPlugin(HookBaseClass):
         :param item: Item to process
         """
 
-        publisher = self.parent
+        if self._is_deferred_to_bg(item):
+            self.logger.info(
+                "Background publish enabled — deferring alembic export and publish to the background process."
+            )
+        else:
+            publisher = self.parent
 
-        # get the path to create and publish
-        publish_path = item.properties["path"]
+            # get the path to create and publish
+            publish_path = item.properties["path"]
 
-        # ensure the publish folder exists:
-        publish_folder = os.path.dirname(publish_path)
-        self.parent.ensure_folder_exists(publish_folder)
+            # ensure the publish folder exists:
+            publish_folder = os.path.dirname(publish_path)
+            self.parent.ensure_folder_exists(publish_folder)
 
-        # set the alembic args that make the most sense when working with Mari.
-        # These flags will ensure the export of an Alembic file that contains
-        # all visible geometry from the current scene together with UV's and
-        # face sets for use in Mari.
-        alembic_args = [
-            # only renderable objects (visible and not templated)
-            "-renderableOnly",
-            # write shading group set assignments (Maya 2015+)
-            "-writeFaceSets",
-            # write uv's (only the current uv set gets written)
-            "-uvWrite",
-        ]
+            # set the alembic args that make the most sense when working with Mari.
+            # These flags will ensure the export of an Alembic file that contains
+            # all visible geometry from the current scene together with UV's and
+            # face sets for use in Mari.
+            alembic_args = [
+                # only renderable objects (visible and not templated)
+                "-renderableOnly",
+                # write shading group set assignments (Maya 2015+)
+                "-writeFaceSets",
+                # write uv's (only the current uv set gets written)
+                "-uvWrite",
+            ]
 
-        # find the animated frame range to use:
-        start_frame, end_frame = _find_scene_animation_range()
-        if start_frame and end_frame:
-            alembic_args.append("-fr %d %d" % (start_frame, end_frame))
+            # find the animated frame range to use:
+            start_frame, end_frame = _find_scene_animation_range()
+            if start_frame and end_frame:
+                alembic_args.append("-fr %d %d" % (start_frame, end_frame))
 
-        # Set the output path:
-        # Note: The AbcExport command expects forward slashes!
-        alembic_args.append("-file '%s'" % publish_path.replace("\\", "/"))
+            # Set the output path:
+            # Note: The AbcExport command expects forward slashes!
+            alembic_args.append("-file '%s'" % publish_path.replace("\\", "/"))
 
-        # build the export command.  Note, use AbcExport -help in Maya for
-        # more detailed Alembic export help
-        abc_export_cmd = 'AbcExport -j "%s"' % " ".join(alembic_args)
+            # build the export command.  Note, use AbcExport -help in Maya for
+            # more detailed Alembic export help
+            abc_export_cmd = 'AbcExport -j "%s"' % " ".join(alembic_args)
 
-        # ...and execute it:
-        try:
-            self.parent.log_debug("Executing command: %s" % abc_export_cmd)
-            mel.eval(abc_export_cmd)
-        except Exception as e:
-            self.logger.error("Failed to export Geometry: %s" % e)
-            return
+            # ...and execute it:
+            try:
+                # Load Alembic plugin if it isn't already
+                if not cmds.pluginInfo("AbcExport", query=True, loaded=True):
+                    cmds.loadPlugin("AbcExport")
+                self.parent.log_debug("Executing command: %s" % abc_export_cmd)
+                mel.eval(abc_export_cmd)
+            except Exception as e:
+                self.logger.error("Failed to export Geometry: %s" % e)
+                return
 
-        # Now that the path has been generated, hand it off to the
-        super().publish(settings, item)
+            # Now that the path has been generated, hand it off to the
+            super().publish(settings, item)
+
+    def finalize(self, settings, item):
+        """
+        Execute the finalization pass. This pass executes once all the publish
+        tasks have completed, and can for example be used to version up files.
+
+        :param settings: Dictionary of Settings. The keys are strings, matching
+            the keys returned in the settings property. The values are `Setting`
+            instances.
+        :param item: Item to process
+        """
+
+        if not self._is_deferred_to_bg(item):
+            super().finalize(settings, item)
+        else:
+            self.logger.info(
+                "Background publish enabled — deferring finalize to the background process."
+            )
+
+    def _is_deferred_to_bg(self, item) -> bool:
+        """Return True if publish item or any ancestor of it has bg publish enabled
+        but we are not currently in a bg process.
+        """
+        root = item
+        while not root.is_root:
+            root = root.parent
+        return bool(root.properties.get("bg_processing")) and not bool(
+            root.properties.get("in_bg_process")
+        )
 
 
 def _find_scene_animation_range():

--- a/hooks/tk-multi-publish2/basic/publish_session_geometry.py
+++ b/hooks/tk-multi-publish2/basic/publish_session_geometry.py
@@ -281,7 +281,7 @@ class MayaSessionGeometryPublishPlugin(HookBaseClass):
             try:
                 # Load Alembic plugin if it isn't already
                 if not cmds.pluginInfo("AbcExport", query=True, loaded=True):
-                    cmds.loadPlugin(plugin)
+                    cmds.loadPlugin("AbcExport")
                 self.parent.log_debug("Executing command: %s" % abc_export_cmd)
                 mel.eval(abc_export_cmd)
             except Exception as e:

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -16,7 +16,6 @@ logger = LogManager.get_logger(__name__)
 
 from . import tk_maya
 
-
 try:
     from . import flowam
 except ImportError as exc:


### PR DESCRIPTION
**Problem:**
After configuring and enabling background publish in Maya, the main publish plugin "Publish to Flow Production Tracking" was executing entirely in the foreground process.

**Root Causes:**
There were two root causes discovered during the investigation.

1. Maya standalone was not being initialized in the right sequence within the run_publish_process.py in tk-multi-bg-publish causing an early exit of the background process.  
(Handled in this PR https://github.com/shotgunsoftware/tk-multi-bg-publish/pull/23)
2. Neither the Maya nor base publish processes were instrumented with the correct gating to support deferring appropriate parts of the publish process to the background process.
(Handled in this PR as well as https://github.com/shotgunsoftware/tk-multi-publish2/pull/230)

**What's in this PR?**
This PR contains the necessary set up and gating within the Maya specific parts of the publish process to support background publishing.

**Details:**
- only save the file during the foreground process
- within the foreground process, save the session path to the publish root item so that the background process can find file to use
- defer dependency calculation to the background publish
- only save next version during the foreground process (this ensures that the background publish is using a file that is insulated from further user changes)