### PR TITLE
SG-44537 Fix "open new file" when no context selected on Maya 27

### DIFF
--- a/engine.py
+++ b/engine.py
@@ -939,6 +939,7 @@ Please report any issues to:
         Suppress scene event callbacks for the duration of a Workfiles file operation.
         Must be paired with exit_file_operation().
         """
+        self._file_operation_depth = getattr(self, "_file_operation_depth", 0) + 1
         self._scene_events_suppressed = True
 
     def exit_file_operation(self):
@@ -946,9 +947,12 @@ Please report any issues to:
         Resume scene event callbacks after a Workfiles file operation.
         The clear is deferred so callbacks already queued during the operation are skipped.
         """
-        maya.utils.executeDeferred(
-            lambda: setattr(self, "_scene_events_suppressed", False)
-        )
+        def _clear_if_idle():
+            self._file_operation_depth = max(0, getattr(self, "_file_operation_depth", 1) - 1)
+            if self._file_operation_depth == 0:
+                self._scene_events_suppressed = False
+
+        maya.utils.executeDeferred(_clear_if_idle)
 
     def _set_project(self):
         """
@@ -969,7 +973,7 @@ Please report any issues to:
             cmds.workspace(directory=proj_path)
         except RuntimeError as e:
             self.logger.error("Maya failed to open Project. Error: %s", str(e))
-            raise e
+            raise
 
     ##########################################################################################
     # panel support

--- a/engine.py
+++ b/engine.py
@@ -684,8 +684,10 @@ Please report any issues to:
                 "Registered new open and save callbacks before changing context."
             )
 
-        # Set the Maya project to match the new context.
-        self._set_project()
+        # Defer the Maya project update to avoid a crash in Maya 2027 where
+        # cmds.workspace() followed immediately by cmds.file(save=True)
+        # causes Maya's native FPT kAfterSave callback to crash.
+        maya.utils.executeDeferred(self._set_project)
 
     def _run_app_instance_commands(self):
         """

--- a/engine.py
+++ b/engine.py
@@ -120,7 +120,9 @@ class SceneEventWatcher(object):
         """
         if watcher.__run_once:
             watcher.stop_watching()
-        watcher.__cb_fn()
+        # Defer to avoid calling Maya commands from within a scene message callback,
+        # which causes a native crash in Maya 2027.
+        maya.utils.executeDeferred(watcher.__cb_fn)
 
     @staticmethod
     def __maya_exiting_callback(watcher):
@@ -212,6 +214,10 @@ def on_scene_event_callback(engine_name, prev_context, menu_name):
     """
     Callback that's run whenever a scene is saved or opened.
     """
+    engine = sgtk.platform.current_engine()
+    if engine and getattr(engine, "_scene_events_suppressed", False):
+        logger.debug("Scene event callback skipped: managed file operation in progress.")
+        return
     try:
         refresh_engine(engine_name, prev_context, menu_name)
     except Exception as e:
@@ -917,6 +923,22 @@ Please report any issues to:
     ##########################################################################################
     # scene and project management
 
+    def enter_file_operation(self):
+        """
+        Suppress scene event callbacks for the duration of a Workfiles file operation.
+        Must be paired with exit_file_operation().
+        """
+        self._scene_events_suppressed = True
+
+    def exit_file_operation(self):
+        """
+        Resume scene event callbacks after a Workfiles file operation.
+        The clear is deferred so callbacks already queued during the operation are skipped.
+        """
+        maya.utils.executeDeferred(
+            lambda: setattr(self, "_scene_events_suppressed", False)
+        )
+
     def _set_project(self):
         """
         Set the maya project
@@ -931,12 +953,12 @@ Please report any issues to:
         self.logger.info("Setting Maya project to '%s'", proj_path)
 
         try:
-            cmds.workspace(proj_path, openWorkspace=True)
+            # Use the `directory` flag instead of `openWorkspace` to avoid
+            # triggering Maya 2027's native Flow integration during workspace init.
+            cmds.workspace(directory=proj_path)
         except RuntimeError as e:
             self.logger.error("Maya failed to open Project. Error: %s", str(e))
             raise e
-
-        cmds.workspace(proj_path, openWorkspace=True)
 
     ##########################################################################################
     # panel support

--- a/engine.py
+++ b/engine.py
@@ -216,7 +216,9 @@ def on_scene_event_callback(engine_name, prev_context, menu_name):
     """
     engine = sgtk.platform.current_engine()
     if engine and getattr(engine, "_scene_events_suppressed", False):
-        logger.debug("Scene event callback skipped: managed file operation in progress.")
+        logger.debug(
+            "Scene event callback skipped: managed file operation in progress."
+        )
         return
     try:
         refresh_engine(engine_name, prev_context, menu_name)

--- a/engine.py
+++ b/engine.py
@@ -220,6 +220,13 @@ def on_scene_event_callback(engine_name, prev_context, menu_name):
         return
     try:
         refresh_engine(engine_name, prev_context, menu_name)
+    except sgtk.platform.TankMissingEngineError:
+        # The resolved context maps to an environment that doesn't include
+        # tk-maya (e.g. site.yml). Stay in the current context.
+        logger.debug(
+            "Engine '%s' not found in the resolved environment. Skipping context change.",
+            engine_name,
+        )
     except Exception as e:
         logger.exception("Could not refresh the engine; error: '%s'" % e)
         exc_type, exc_value, exc_traceback = sys.exc_info()

--- a/python/__init__.py
+++ b/python/__init__.py
@@ -16,7 +16,6 @@ logger = LogManager.get_logger(__name__)
 
 from . import tk_maya
 
-
 try:
     from . import flowam
 except ImportError as exc:


### PR DESCRIPTION
This pull request introduces several important changes to improve stability and prevent crashes with Maya 2027, particularly around scene event callbacks and project management. The main focus is on deferring potentially unsafe Maya commands, suppressing callbacks during managed file operations, and updating workspace handling to avoid new Maya integration issues.

## The Issue

Maya 2027 crashes when selecting a context after open/save.

- Scenario 1: Use file open to create a new workfile on Maya startup. Add a shape. After saving it Maya hangs and crashes.
- Scenario 2: Add a shape after Maya startup. Use multi-workfiles to select a context and save. Maya hangs and crashes.

This PR attempts to fix scenario 1.